### PR TITLE
feat: merchant suggestions in new transaction

### DIFF
--- a/app/src/main/java/dev/pandesal/sbp/data/dao/TransactionDao.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/dao/TransactionDao.kt
@@ -220,6 +220,18 @@ interface TransactionDao {
     """)
     fun getTotalAmountByCategory(type: String): Flow<List<CategoryTotalSummary>>
 
+    @Query(
+        """
+        SELECT DISTINCT merchantName
+        FROM transactions
+        WHERE category_id = :categoryId
+          AND merchantName IS NOT NULL
+          AND merchantName != ''
+        ORDER BY merchantName
+        """
+    )
+    fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>>
+
     @Upsert
     suspend fun insert(value: TransactionEntity)
 

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/TransactionRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/TransactionRepository.kt
@@ -111,6 +111,9 @@ class TransactionRepository @Inject constructor(
         dao.getTotalAmountByCategory(type.name)
             .map { list -> list.map { it.categoryId to it.total } }
 
+    override fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>> =
+        dao.getMerchantsByCategoryId(categoryId)
+
     override suspend fun insert(transaction: Transaction) =
         dao.insert(transaction.toEntity())
 

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/TransactionRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/TransactionRepositoryInterface.kt
@@ -27,6 +27,7 @@ interface TransactionRepositoryInterface {
     fun getPagedTransactions(limit: Int, offset: Int): Flow<List<Transaction>>
     fun getPagedTransactionsByCategory(categoryId: String, limit: Int, offset: Int): Flow<List<Transaction>>
     fun getTotalAmountByCategory(type: TransactionType): Flow<List<Pair<Int, BigDecimal>>>
+    fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>>
     suspend fun insert(transaction: Transaction)
     suspend fun delete(transaction: Transaction)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/TransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/TransactionUseCase.kt
@@ -59,6 +59,9 @@ class TransactionUseCase @Inject constructor(
     fun getTotalAmountByCategory(type: TransactionType): Flow<List<Pair<Int, BigDecimal>>> =
         repository.getTotalAmountByCategory(type)
 
+    fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>> =
+        repository.getMerchantsByCategoryId(categoryId)
+
     suspend fun insert(transaction: Transaction) =
         repository.insert(transaction)
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -77,6 +77,7 @@ fun NewTransactionScreen(
         NewTransactionScreen(
             state.groupedCategories,
             state.transaction,
+            state.merchants,
             onSave = {
                 viewModel.saveTransaction {
 
@@ -98,6 +99,7 @@ fun NewTransactionScreen(
 private fun NewTransactionScreen(
     groupedCategories: Map<CategoryGroup, List<Category>>,
     transaction: Transaction,
+    merchants: List<String>,
     onSave: (Transaction) -> Unit,
     onCancel: () -> Unit,
     onUpdate: (Transaction) -> Unit
@@ -115,6 +117,7 @@ private fun NewTransactionScreen(
     val showDatePicker = remember { mutableStateOf(false) }
 
     var expanded by remember { mutableStateOf(false) }
+    var merchantExpanded by remember { mutableStateOf(false) }
 
     // Transaction Type Tabs
     val transactionTypes = listOf(TransactionType.INFLOW, TransactionType.OUTFLOW, TransactionType.TRANSFER)
@@ -334,8 +337,29 @@ private fun NewTransactionScreen(
                         Icon(
                             Icons.TwoTone.Favorite,
                             contentDescription = "Reorder",
-                            modifier = Modifier.padding(end = 8.dp).size(24.dp)
+                            modifier = Modifier
+                                .padding(end = 8.dp)
+                                .size(24.dp)
+                                .clickable { merchantExpanded = true }
                         )
+                    }
+                }
+                if (merchantExpanded) {
+                    ModalBottomSheet(onDismissRequest = { merchantExpanded = false }) {
+                        LazyColumn {
+                            items(merchants) { item ->
+                                Text(
+                                    text = item,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            onUpdate(transaction.copy(merchantName = item))
+                                            merchantExpanded = false
+                                        }
+                                        .padding(16.dp)
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
@@ -9,7 +9,8 @@ sealed interface NewTransactionUiState {
     data object Loading : NewTransactionUiState
     data class Success(
         val groupedCategories: Map<CategoryGroup, List<Category>>,
-        val transaction: Transaction
+        val transaction: Transaction,
+        val merchants: List<String>
     ) : NewTransactionUiState
     data class Error(val errorMessage: String) : NewTransactionUiState
 }


### PR DESCRIPTION
## Summary
- offer merchant suggestion dropdown in new transaction flow
- load merchant names from previous transactions by category

## Testing
- `gradlew tasks` *(fails: No route to host)*