### PR TITLE
Fix Category mapping bug

### DIFF
--- a/app/src/main/java/dev/pandesal/sbp/data/local/Category.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/Category.kt
@@ -79,9 +79,10 @@ fun CategoryGroup.toEntity(): CategoryGroupEntity {
         icon = icon,
         weight = weight,
         isFavorite = isFavorite,
+        isArchived = isArchived,
+        isSystemSet = isSystemSet,
         description = description,
-
-        )
+    )
 }
 
 fun CategoryGroupEntity.toDomainModel(): CategoryGroup {
@@ -91,7 +92,9 @@ fun CategoryGroupEntity.toDomainModel(): CategoryGroup {
         icon = icon,
         weight = weight,
         isFavorite = isFavorite,
-        description = description
+        description = description,
+        isArchived = isArchived,
+        isSystemSet = isSystemSet
     )
 }
 
@@ -104,7 +107,9 @@ fun Category.toEntity(): CategoryEntity {
         weight = weight,
         isFavorite = isFavorite,
         description = description,
-        categoryType = categoryType.name
+        categoryType = categoryType.name,
+        isArchived = isArchived,
+        isSystemSet = isSystemSet,
     )
 }
 
@@ -117,6 +122,8 @@ fun CategoryEntity.toDomainModel(): Category {
         weight = weight,
         isFavorite = isFavorite,
         description = description,
+        isArchived = isArchived,
+        isSystemSet = isSystemSet,
         categoryType = TransactionType.valueOf(categoryType)
     )
 }

--- a/app/src/test/java/dev/pandesal/sbp/local/MappingTests.kt
+++ b/app/src/test/java/dev/pandesal/sbp/local/MappingTests.kt
@@ -1,0 +1,59 @@
+package dev.pandesal.sbp.local
+
+import dev.pandesal.sbp.data.local.CategoryEntity
+import dev.pandesal.sbp.data.local.CategoryGroupEntity
+import dev.pandesal.sbp.data.local.toDomainModel
+import dev.pandesal.sbp.data.local.toEntity
+import dev.pandesal.sbp.domain.model.Category
+import dev.pandesal.sbp.domain.model.CategoryGroup
+import dev.pandesal.sbp.domain.model.TransactionType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MappingTests {
+    @Test
+    fun `category group mapping preserves flags`() {
+        val group = CategoryGroup(
+            id = 1,
+            name = "Test",
+            description = "desc",
+            icon = "icon",
+            weight = 5,
+            isSystemSet = true,
+            isFavorite = true,
+            isArchived = true
+        )
+
+        val entity = group.toEntity()
+        val back = entity.toDomainModel()
+
+        assertEquals(group.isArchived, entity.isArchived)
+        assertEquals(group.isSystemSet, entity.isSystemSet)
+        assertEquals(group.isArchived, back.isArchived)
+        assertEquals(group.isSystemSet, back.isSystemSet)
+    }
+
+    @Test
+    fun `category mapping preserves flags`() {
+        val category = Category(
+            id = 1,
+            name = "Test",
+            description = "desc",
+            icon = "icon",
+            categoryGroupId = 2,
+            categoryType = TransactionType.EXPENSE,
+            weight = 1,
+            isSystemSet = true,
+            isFavorite = true,
+            isArchived = true
+        )
+
+        val entity = category.toEntity()
+        val back = entity.toDomainModel()
+
+        assertEquals(category.isArchived, entity.isArchived)
+        assertEquals(category.isSystemSet, entity.isSystemSet)
+        assertEquals(category.isArchived, back.isArchived)
+        assertEquals(category.isSystemSet, back.isSystemSet)
+    }
+}


### PR DESCRIPTION
## Summary
- preserve `isArchived` and `isSystemSet` when mapping between domain and entity models
- add unit tests verifying that these flags survive the conversion

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] not found)*