### PR TITLE
Add settings screen

### DIFF
--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -11,6 +11,7 @@ import dev.pandesal.sbp.presentation.categories.CategoriesScreen
 import dev.pandesal.sbp.presentation.home.HomeScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
+import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -23,6 +24,8 @@ sealed class NavigationDestination() {
     data object Insights : NavigationDestination()
     @Serializable
     data object More : NavigationDestination()
+    @Serializable
+    data object Settings : NavigationDestination()
     @Serializable
     data object Transactions : NavigationDestination()
     @Serializable
@@ -66,6 +69,10 @@ fun AppNavigation(navController: NavHostController) {
             composable<NavigationDestination.More> {
 //                MoreScreen()
                 HomeScreen()
+            }
+
+            composable<NavigationDestination.Settings> {
+                SettingsScreen()
             }
 
         }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -152,8 +152,14 @@ class MainActivity : ComponentActivity() {
                                 }) {
                                     Icon(Icons.Filled.BarChart, contentDescription = "Localized description")
                                 }
-                                IconButton(onClick = { /* doSomething() */ }) {
-                                    Icon(Icons.Filled.MoreVert, contentDescription = "Localized description")
+                                IconButton(onClick = {
+                                    navController.navigate(NavigationDestination.Settings) {
+                                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                }) {
+                                    Icon(Icons.Filled.MoreVert, contentDescription = "Settings")
                                 }
                             },
                             scrollBehavior = exitAlwaysScrollBehavior

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
@@ -1,0 +1,84 @@
+package dev.pandesal.sbp.presentation.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen() {
+    SettingsContent()
+}
+
+private data class SettingItem(
+    val title: String,
+    val type: SettingType
+)
+
+private enum class SettingType { SWITCH, TEXT }
+
+@Composable
+private fun SettingsContent() {
+    var darkMode by remember { mutableStateOf(false) }
+    var notificationsEnabled by remember { mutableStateOf(true) }
+    val items = listOf(
+        SettingItem("Dark mode", SettingType.SWITCH),
+        SettingItem("Enable notifications", SettingType.SWITCH),
+        SettingItem("Currency", SettingType.TEXT)
+    )
+
+    LazyColumn(
+        modifier = Modifier.padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        item {
+            Text(
+                text = "Settings",
+                style = MaterialTheme.typography.headlineMedium
+            )
+        }
+        items(items) { item ->
+            when (item.title) {
+                "Dark mode" -> SettingSwitch(item.title, darkMode) { darkMode = it }
+                "Enable notifications" -> SettingSwitch(item.title, notificationsEnabled) { notificationsEnabled = it }
+                "Currency" -> SettingText(item.title, "USD")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingSwitch(title: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = title, style = MaterialTheme.typography.bodyLarge)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun SettingText(title: String, value: String) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = title, style = MaterialTheme.typography.bodyLarge)
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+


### PR DESCRIPTION
## Summary
- create a simple Settings screen with switches for dark mode and notifications
- hook settings into navigation
- open settings from the bottom toolbar

## Testing
- `./gradlew test` *(fails: NoRouteToHostException while downloading Gradle)*