### PR TITLE
Add Insights screen

### DIFF
--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.composable
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.presentation.categories.CategoriesScreen
 import dev.pandesal.sbp.presentation.home.HomeScreen
+import dev.pandesal.sbp.presentation.insights.InsightsScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import kotlinx.serialization.Serializable
@@ -59,8 +60,7 @@ fun AppNavigation(navController: NavHostController) {
             }
 
             composable<NavigationDestination.Insights> {
-//                InsightsScreen()
-                HomeScreen()
+                InsightsScreen()
             }
 
             composable<NavigationDestination.More> {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -149,6 +149,11 @@ class MainActivity : ComponentActivity() {
                                 }
 
                                 IconButton(onClick = {
+                                    navController.navigate(NavigationDestination.Insights) {
+                                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
                                 }) {
                                     Icon(Icons.Filled.BarChart, contentDescription = "Localized description")
                                 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -1,0 +1,52 @@
+package dev.pandesal.sbp.presentation.insights
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
+import dev.pandesal.sbp.presentation.insights.components.BudgetOutflowEntry
+import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
+import dev.pandesal.sbp.presentation.insights.components.CashflowEntry
+import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
+import dev.pandesal.sbp.presentation.model.NetWorthUiModel
+
+@Composable
+fun InsightsScreen() {
+    val dummyNetWorth = listOf(
+        NetWorthUiModel("Jan", 40000.0, 10000.0),
+        NetWorthUiModel("Feb", 42000.0, 9500.0),
+        NetWorthUiModel("Mar", 45000.0, 8700.0),
+        NetWorthUiModel("Apr", 47000.0, 8000.0)
+    )
+    val dummyCashflow = listOf(
+        CashflowEntry("Jan", 2000.0, 1500.0),
+        CashflowEntry("Feb", 2200.0, 1800.0),
+        CashflowEntry("Mar", 2500.0, 1600.0),
+        CashflowEntry("Apr", 2400.0, 1700.0)
+    )
+    val dummyBudget = listOf(
+        BudgetOutflowEntry("Jan", 3000.0, 2800.0),
+        BudgetOutflowEntry("Feb", 3100.0, 3300.0),
+        BudgetOutflowEntry("Mar", 3200.0, 3000.0),
+        BudgetOutflowEntry("Apr", 3300.0, 3400.0)
+    )
+
+    Column(
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp)
+    ) {
+        CashflowLineChart(dummyCashflow)
+        Spacer(modifier = Modifier.height(16.dp))
+        BudgetVsOutflowChart(dummyBudget)
+        Spacer(modifier = Modifier.height(16.dp))
+        NetWorthBarChart(dummyNetWorth)
+    }
+}
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
@@ -1,4 +1,4 @@
-package dev.pandesal.sbp.presentation.home.components
+package dev.pandesal.sbp.presentation.insights.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -17,17 +18,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 import kotlin.math.max
 
+data class BudgetOutflowEntry(val label: String, val budget: Double, val outflow: Double)
+
 @Composable
-fun NetWorthBarChart(
-    data: List<NetWorthUiModel>,
-    barWidth: Dp = 16.dp,
-    modifier: Modifier = Modifier
+fun BudgetVsOutflowChart(
+    entries: List<BudgetOutflowEntry>,
+    modifier: Modifier = Modifier,
+    barWidth: Dp = 16.dp
 ) {
     Card(
         modifier = modifier
@@ -41,9 +42,9 @@ fun NetWorthBarChart(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
-            Text("Net Worth", style = MaterialTheme.typography.titleMedium)
+            Text("Budget vs Outflow", style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(8.dp))
-            Text("Assets vs Liabilities", style = MaterialTheme.typography.bodySmall)
+            Text("This Month", style = MaterialTheme.typography.bodySmall)
             Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier
@@ -52,28 +53,28 @@ fun NetWorthBarChart(
             ) {
                 androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
                     val spacing = barWidth.toPx()
-                    val maxY = data.maxOf { max(it.assets, it.liabilities) }
+                    val maxY = entries.maxOf { max(it.budget, it.outflow) }
                     val chartHeight = size.height - spacing
-                    val groupWidth = (size.width - spacing * 2) / data.size
-                    data.forEachIndexed { index, entry ->
-                        val assetsHeight = chartHeight * (entry.assets / maxY).toFloat()
-                        val liabilitiesHeight = chartHeight * (entry.liabilities / maxY).toFloat()
+                    val groupWidth = (size.width - spacing * 2) / entries.size
+                    entries.forEachIndexed { index, entry ->
+                        val budgetHeight = chartHeight * (entry.budget / maxY).toFloat()
+                        val outflowHeight = chartHeight * (entry.outflow / maxY).toFloat()
                         val xOffset = spacing + index * groupWidth
                         drawRect(
                             color = MaterialTheme.colorScheme.primary,
                             topLeft = androidx.compose.ui.geometry.Offset(
                                 xOffset,
-                                size.height - assetsHeight
+                                size.height - budgetHeight
                             ),
-                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), assetsHeight)
+                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), budgetHeight)
                         )
                         drawRect(
                             color = MaterialTheme.colorScheme.error,
                             topLeft = androidx.compose.ui.geometry.Offset(
                                 xOffset + barWidth.toPx() + 4.dp.toPx(),
-                                size.height - liabilitiesHeight
+                                size.height - outflowHeight
                             ),
-                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), liabilitiesHeight)
+                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), outflowHeight)
                         )
                     }
                 }
@@ -84,7 +85,7 @@ fun NetWorthBarChart(
                         .fillMaxWidth(),
                     horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceAround
                 ) {
-                    data.forEach { entry ->
+                    entries.forEach { entry ->
                         Text(entry.label, style = MaterialTheme.typography.labelSmall)
                     }
                 }
@@ -92,3 +93,4 @@ fun NetWorthBarChart(
         }
     }
 }
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CashflowLineChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CashflowLineChart.kt
@@ -1,4 +1,4 @@
-package dev.pandesal.sbp.presentation.home.components
+package dev.pandesal.sbp.presentation.insights.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -18,16 +18,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 import kotlin.math.max
 
+data class CashflowEntry(val label: String, val inflow: Double, val outflow: Double)
+
 @Composable
-fun NetWorthBarChart(
-    data: List<NetWorthUiModel>,
-    barWidth: Dp = 16.dp,
-    modifier: Modifier = Modifier
+fun CashflowLineChart(
+    entries: List<CashflowEntry>,
+    modifier: Modifier = Modifier,
+    strokeWidth: Dp = 2.dp
 ) {
     Card(
         modifier = modifier
@@ -41,9 +44,9 @@ fun NetWorthBarChart(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
-            Text("Net Worth", style = MaterialTheme.typography.titleMedium)
+            Text("Cashflow", style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(8.dp))
-            Text("Assets vs Liabilities", style = MaterialTheme.typography.bodySmall)
+            Text("Inflow vs Outflow", style = MaterialTheme.typography.bodySmall)
             Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier
@@ -51,31 +54,35 @@ fun NetWorthBarChart(
                     .height(100.dp)
             ) {
                 androidx.compose.foundation.Canvas(modifier = Modifier.fillMaxSize()) {
-                    val spacing = barWidth.toPx()
-                    val maxY = data.maxOf { max(it.assets, it.liabilities) }
+                    val spacing = 16.dp.toPx()
+                    val maxY = entries.maxOf { max(it.inflow, it.outflow) }
                     val chartHeight = size.height - spacing
-                    val groupWidth = (size.width - spacing * 2) / data.size
-                    data.forEachIndexed { index, entry ->
-                        val assetsHeight = chartHeight * (entry.assets / maxY).toFloat()
-                        val liabilitiesHeight = chartHeight * (entry.liabilities / maxY).toFloat()
-                        val xOffset = spacing + index * groupWidth
-                        drawRect(
-                            color = MaterialTheme.colorScheme.primary,
-                            topLeft = androidx.compose.ui.geometry.Offset(
-                                xOffset,
-                                size.height - assetsHeight
-                            ),
-                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), assetsHeight)
-                        )
-                        drawRect(
-                            color = MaterialTheme.colorScheme.error,
-                            topLeft = androidx.compose.ui.geometry.Offset(
-                                xOffset + barWidth.toPx() + 4.dp.toPx(),
-                                size.height - liabilitiesHeight
-                            ),
-                            size = androidx.compose.ui.geometry.Size(barWidth.toPx(), liabilitiesHeight)
-                        )
+                    val stepX = (size.width - spacing * 2) / (entries.size - 1)
+
+                    val inflowPath = Path()
+                    val outflowPath = Path()
+                    entries.forEachIndexed { index, entry ->
+                        val x = spacing + stepX * index
+                        val inflowY = chartHeight * (1f - (entry.inflow / maxY).toFloat())
+                        val outflowY = chartHeight * (1f - (entry.outflow / maxY).toFloat())
+                        if (index == 0) {
+                            inflowPath.moveTo(x, inflowY)
+                            outflowPath.moveTo(x, outflowY)
+                        } else {
+                            inflowPath.lineTo(x, inflowY)
+                            outflowPath.lineTo(x, outflowY)
+                        }
                     }
+                    drawPath(
+                        path = inflowPath,
+                        color = MaterialTheme.colorScheme.primary,
+                        style = Stroke(width = strokeWidth.toPx())
+                    )
+                    drawPath(
+                        path = outflowPath,
+                        color = MaterialTheme.colorScheme.error,
+                        style = Stroke(width = strokeWidth.toPx())
+                    )
                 }
                 Row(
                     modifier = Modifier
@@ -84,7 +91,7 @@ fun NetWorthBarChart(
                         .fillMaxWidth(),
                     horizontalArrangement = androidx.compose.foundation.layout.Arrangement.SpaceAround
                 ) {
-                    data.forEach { entry ->
+                    entries.forEach { entry ->
                         Text(entry.label, style = MaterialTheme.typography.labelSmall)
                     }
                 }
@@ -92,3 +99,4 @@ fun NetWorthBarChart(
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- implement `InsightsScreen` with simple charts for Cashflow, Budget vs Outflow and Net Worth
- use Canvas to draw lines and bars with dummy data
- wire chart components with basic drawing logic

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*