### PR TITLE
Fix notification popup anchor

### DIFF
--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -248,17 +248,19 @@ private fun HomeScreenContent(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Spacer(Modifier.weight(1f))
-            IconButton(onClick = { showNotifications = true }) {
-                Icon(
-                    painterResource(R.drawable.ic_notif),
-                    contentDescription = "Notifications"
+            Box(modifier = Modifier.wrapContentSize(Alignment.TopEnd)) {
+                IconButton(onClick = { showNotifications = true }) {
+                    Icon(
+                        painterResource(R.drawable.ic_notif),
+                        contentDescription = "Notifications"
+                    )
+                }
+                NotificationsPopup(
+                    notifications = notifications,
+                    expanded = showNotifications,
+                    onDismissRequest = { showNotifications = false }
                 )
             }
-            NotificationsPopup(
-                notifications = notifications,
-                expanded = showNotifications,
-                onDismissRequest = { showNotifications = false }
-            )
         }
 
 


### PR DESCRIPTION
## Summary
- anchor notifications popup to the top end of the icon so it opens on the right

## Testing
- `./gradlew test --quiet` *(fails: No route to host while downloading gradle)*