### PR TITLE
Add serializer and account type extension tests

### DIFF
--- a/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
@@ -1,0 +1,15 @@
+package dev.pandesal.sbp.extensions
+
+import dev.pandesal.sbp.domain.model.AccountType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AccountTypeExtensionsTest {
+    @Test
+    fun `label returns expected string for each account type`() {
+        assertEquals("Cash wallet", AccountType.CASH_WALLET.label())
+        assertEquals("Mobile digital wallet", AccountType.MOBILE_DIGITAL_WALLET.label())
+        assertEquals("Bank account", AccountType.BANK_ACCOUNT.label())
+        assertEquals("Credit card", AccountType.CREDIT_CARD.label())
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/extensions/SerializersTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/extensions/SerializersTest.kt
@@ -1,0 +1,42 @@
+package dev.pandesal.sbp.extensions
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Serializable
+data class BigDecimalWrapper(
+    @Serializable(with = BigDecimalSerializer::class)
+    val value: BigDecimal
+)
+
+@Serializable
+data class LocalDateWrapper(
+    @Serializable(with = LocalDateSerializer::class)
+    val date: LocalDate
+)
+
+class SerializersTest {
+    @Test
+    fun `big decimal round trip`() {
+        val wrapper = BigDecimalWrapper(BigDecimal("1234.56"))
+        val json = Json.encodeToString(wrapper)
+        assertEquals("{\"value\":\"1234.56\"}", json)
+        val back = Json.decodeFromString<BigDecimalWrapper>(json)
+        assertEquals(wrapper, back)
+    }
+
+    @Test
+    fun `local date round trip`() {
+        val wrapper = LocalDateWrapper(LocalDate.of(2024, 1, 2))
+        val json = Json.encodeToString(wrapper)
+        assertEquals("{\"date\":\"2024-01-02\"}", json)
+        val back = Json.decodeFromString<LocalDateWrapper>(json)
+        assertEquals(wrapper, back)
+    }
+}


### PR DESCRIPTION
## Summary
- add account type extension unit tests
- add serializer roundtrip tests for BigDecimal and LocalDate

## Testing
- `gradle test --no-daemon` *(fails: plugin not found)*