### PR TITLE
Add financial app usage detection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
+
     <application
         android:name=".presentation.ApplicationClass"
         android:allowBackup="true"
@@ -32,6 +35,9 @@
                 <action android:name="android.service.notification.NotificationListenerService" />
             </intent-filter>
         </service>
+        <service
+            android:name=".notification.FinancialAppUsageService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
@@ -1,0 +1,52 @@
+package dev.pandesal.sbp.notification
+
+import android.app.Service
+import android.app.usage.UsageEvents
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+
+class FinancialAppUsageService : Service() {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        detectFinancialApps()
+        stopSelf(startId)
+        return START_NOT_STICKY
+    }
+
+    private fun detectFinancialApps() {
+        val manager = getSystemService(Context.USAGE_STATS_SERVICE) as? UsageStatsManager ?: return
+        val now = System.currentTimeMillis()
+        val events = manager.queryEvents(now - CHECK_INTERVAL_MS, now)
+        val event = UsageEvents.Event()
+        val detectedPackages = mutableSetOf<String>()
+        while (events.hasNextEvent()) {
+            events.getNextEvent(event)
+            if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND ||
+                event.eventType == UsageEvents.Event.ACTIVITY_RESUMED) {
+                if (FINANCIAL_KEYWORDS.any { event.packageName.contains(it, ignoreCase = true) }) {
+                    detectedPackages.add(event.packageName)
+                }
+            }
+        }
+        detectedPackages.forEach { pkg ->
+            val appName = try {
+                val info = packageManager.getApplicationInfo(pkg, 0)
+                packageManager.getApplicationLabel(info).toString()
+            } catch (_: Exception) {
+                pkg
+            }
+            InAppNotificationCenter.postNotification("Did you transact with $appName?")
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    companion object {
+        private const val CHECK_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
+        val FINANCIAL_KEYWORDS = listOf(
+            "bpi", "bdo", "metrobank", "securitybank", "maybank",
+            "eastwest", "rcbc", "unionbank", "gcash", "maya"
+        )
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
@@ -1,0 +1,14 @@
+package dev.pandesal.sbp.notification
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object InAppNotificationCenter {
+    private val _notifications = MutableStateFlow<List<String>>(emptyList())
+    val notifications: StateFlow<List<String>> = _notifications.asStateFlow()
+
+    fun postNotification(message: String) {
+        _notifications.value = _notifications.value + message
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -70,6 +70,7 @@ import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.FilterTab
 import dev.pandesal.sbp.presentation.components.NotificationsPopup
 import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
+import dev.pandesal.sbp.notification.InAppNotificationCenter
 import dev.pandesal.sbp.presentation.transactions.TransactionsContent
 import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
 import dev.pandesal.sbp.presentation.transactions.TransactionsViewModel
@@ -87,6 +88,7 @@ fun HomeScreen(
     val navController = LocalNavigationManager.current
     val homeState = viewModel.uiState.collectAsState()
     val transactionsState = transactionsViewModel.uiState.collectAsState()
+    val notificationsState = InAppNotificationCenter.notifications.collectAsState()
 
     if (homeState.value is HomeUiState.Success &&
         transactionsState.value is TransactionsUiState.Success
@@ -105,6 +107,7 @@ fun HomeScreen(
             totalAmount = totalAmount,
             categoryPercentages = categoryPercentages,
             transactions = txState.transactions,
+            notifications = notificationsState.value,
             onViewAllTransactions = {
                 navController.navigate(NavigationDestination.Transactions)
             }


### PR DESCRIPTION
## Summary
- create `InAppNotificationCenter` singleton to hold in‑app notification list
- add `FinancialAppUsageService` to detect recently used financial apps via `UsageStatsManager`
- surface notifications on `HomeScreen`
- register service and permission in `AndroidManifest`

## Testing
- `./gradlew test` *(fails: No route to host)*