### PR TITLE
Implement settings screen features

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
 
     implementation(libs.androidx.hilt.navigation.compose)
 
+    implementation(libs.androidx.datastore.preferences)
+
     implementation(libs.coil.compose)
     implementation(libs.lottie.compose)
     implementation(libs.reorderable)

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
@@ -1,0 +1,47 @@
+package dev.pandesal.sbp.data.repository
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.pandesal.sbp.domain.model.Settings
+import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private val Context.settingsDataStore by preferencesDataStore(name = "settings")
+
+class SettingsRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) : SettingsRepositoryInterface {
+
+    private object Keys {
+        val DARK_MODE = booleanPreferencesKey("dark_mode")
+        val NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
+        val CURRENCY = stringPreferencesKey("currency")
+    }
+
+    override fun getSettings(): Flow<Settings> =
+        context.settingsDataStore.data.map { prefs ->
+            Settings(
+                darkMode = prefs[Keys.DARK_MODE] ?: false,
+                notificationsEnabled = prefs[Keys.NOTIFICATIONS_ENABLED] ?: true,
+                currency = prefs[Keys.CURRENCY] ?: "PHP"
+            )
+        }
+
+    override suspend fun setDarkMode(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.DARK_MODE] = enabled }
+    }
+
+    override suspend fun setNotificationsEnabled(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.NOTIFICATIONS_ENABLED] = enabled }
+    }
+
+    override suspend fun setCurrency(currency: String) {
+        context.settingsDataStore.edit { it[Keys.CURRENCY] = currency }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -13,9 +13,11 @@ import dev.pandesal.sbp.data.local.SbpDatabase
 import dev.pandesal.sbp.data.repository.CategoryRepository
 import dev.pandesal.sbp.data.repository.TransactionRepository
 import dev.pandesal.sbp.data.repository.AccountRepository
+import dev.pandesal.sbp.data.repository.SettingsRepository
 import dev.pandesal.sbp.domain.repository.CategoryRepositoryInterface
 import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
 import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
+import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -71,6 +73,14 @@ object DataModule {
         accountDao: AccountDao
     ): AccountRepositoryInterface {
         return AccountRepository(accountDao)
+    }
+
+    @Singleton
+    @Provides
+    fun provideSettingsRepository(
+        @ApplicationContext context: Context
+    ): SettingsRepositoryInterface {
+        return SettingsRepository(context)
     }
 
 

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
@@ -1,0 +1,7 @@
+package dev.pandesal.sbp.domain.model
+
+data class Settings(
+    val darkMode: Boolean = false,
+    val notificationsEnabled: Boolean = true,
+    val currency: String = "PHP"
+)

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
@@ -1,0 +1,11 @@
+package dev.pandesal.sbp.domain.repository
+
+import dev.pandesal.sbp.domain.model.Settings
+import kotlinx.coroutines.flow.Flow
+
+interface SettingsRepositoryInterface {
+    fun getSettings(): Flow<Settings>
+    suspend fun setDarkMode(enabled: Boolean)
+    suspend fun setNotificationsEnabled(enabled: Boolean)
+    suspend fun setCurrency(currency: String)
+}

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
@@ -1,0 +1,16 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.Settings
+import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class SettingsUseCase @Inject constructor(
+    private val repository: SettingsRepositoryInterface
+) {
+    fun getSettings(): Flow<Settings> = repository.getSettings()
+
+    suspend fun setDarkMode(enabled: Boolean) = repository.setDarkMode(enabled)
+    suspend fun setNotificationsEnabled(enabled: Boolean) = repository.setNotificationsEnabled(enabled)
+    suspend fun setCurrency(currency: String) = repository.setCurrency(currency)
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -58,7 +60,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             val exitAlwaysScrollBehavior =
                 FloatingToolbarDefaults.exitAlwaysScrollBehavior(exitDirection = Bottom)
-            StopBeingPoorTheme {
+            val settingsViewModel: dev.pandesal.sbp.presentation.settings.SettingsViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+            val settings by settingsViewModel.settings.collectAsState()
+            StopBeingPoorTheme(darkTheme = settings.darkMode) {
                 val navController = rememberNavController()
                 var fabVisible by remember { mutableStateOf(true) }
                 var expanded by rememberSaveable { mutableStateOf(true) }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
@@ -10,17 +10,37 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.clickable
 
 @Composable
-fun SettingsScreen() {
-    SettingsContent()
+fun SettingsScreen(
+    viewModel: SettingsViewModel = hiltViewModel()
+) {
+    val settings by viewModel.settings.collectAsState()
+    SettingsContent(
+        settings = settings,
+        onDarkModeChange = viewModel::setDarkMode,
+        onNotificationsChange = viewModel::setNotificationsEnabled,
+        onCurrencyChange = viewModel::setCurrency
+    )
 }
 
 private data class SettingItem(
@@ -31,9 +51,19 @@ private data class SettingItem(
 private enum class SettingType { SWITCH, TEXT }
 
 @Composable
-private fun SettingsContent() {
-    var darkMode by remember { mutableStateOf(false) }
-    var notificationsEnabled by remember { mutableStateOf(true) }
+private fun SettingsContent(
+    settings: dev.pandesal.sbp.domain.model.Settings,
+    onDarkModeChange: (Boolean) -> Unit,
+    onNotificationsChange: (Boolean) -> Unit,
+    onCurrencyChange: (String) -> Unit
+) {
+    var darkMode by remember { mutableStateOf(settings.darkMode) }
+    var notificationsEnabled by remember { mutableStateOf(settings.notificationsEnabled) }
+    var showCurrencySheet by remember { mutableStateOf(false) }
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        notificationsEnabled = granted
+        onNotificationsChange(granted)
+    }
     val items = listOf(
         SettingItem("Dark mode", SettingType.SWITCH),
         SettingItem("Enable notifications", SettingType.SWITCH),
@@ -56,9 +86,45 @@ private fun SettingsContent() {
                 elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
             ) {
                 when (item.title) {
-                    "Dark mode" -> SettingSwitch(item.title, darkMode) { darkMode = it }
-                    "Enable notifications" -> SettingSwitch(item.title, notificationsEnabled) { notificationsEnabled = it }
-                    "Currency" -> SettingText(item.title, "USD")
+                    "Dark mode" -> SettingSwitch(item.title, darkMode) {
+                        darkMode = it
+                        onDarkModeChange(it)
+                    }
+                    "Enable notifications" -> SettingSwitch(item.title, notificationsEnabled) {
+                        notificationsEnabled = it
+                        if (it) {
+                            val permission = Manifest.permission.POST_NOTIFICATIONS
+                            val context = LocalContext.current
+                            if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+                                onNotificationsChange(true)
+                            } else {
+                                launcher.launch(permission)
+                            }
+                        } else {
+                            onNotificationsChange(false)
+                        }
+                    }
+                    "Currency" -> SettingText(item.title, settings.currency) {
+                        showCurrencySheet = true
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCurrencySheet) {
+        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val currencies = listOf("PHP", "USD", "EUR", "JPY")
+        ModalBottomSheet(onDismissRequest = { showCurrencySheet = false }, sheetState = sheetState) {
+            LazyColumn(modifier = Modifier.padding(16.dp)) {
+                items(currencies) { currency ->
+                    ListItem(
+                        headlineContent = { Text(currency) },
+                        modifier = Modifier.clickable {
+                            onCurrencyChange(currency)
+                            showCurrencySheet = false
+                        }
+                    )
                 }
             }
         }
@@ -74,10 +140,11 @@ private fun SettingSwitch(title: String, checked: Boolean, onCheckedChange: (Boo
 }
 
 @Composable
-private fun SettingText(title: String, value: String) {
+private fun SettingText(title: String, value: String, onClick: () -> Unit) {
     ListItem(
         headlineContent = { Text(title) },
-        supportingContent = { Text(value) }
+        supportingContent = { Text(value) },
+        modifier = Modifier.clickable { onClick() }
     )
 }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
@@ -1,0 +1,34 @@
+package dev.pandesal.sbp.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.Settings
+import dev.pandesal.sbp.domain.usecase.SettingsUseCase
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    private val useCase: SettingsUseCase
+) : ViewModel() {
+
+    val settings: StateFlow<Settings> = useCase.getSettings()
+        .stateIn(viewModelScope, SharingStarted.Lazily, Settings())
+
+    fun setDarkMode(enabled: Boolean) {
+        viewModelScope.launch { useCase.setDarkMode(enabled) }
+    }
+
+    fun setNotificationsEnabled(enabled: Boolean) {
+        viewModelScope.launch { useCase.setNotificationsEnabled(enabled) }
+    }
+
+    fun setCurrency(currency: String) {
+        viewModelScope.launch { useCase.setCurrency(currency) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ generativeai = "0.9.0"
 googleAndroidLibrariesMapsplatformSecretsGradlePlugin = "2.0.1"
 reorderable = "2.4.3"
 material3 = "1.4.0-alpha14"
+datastore = "1.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -73,6 +74,7 @@ mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoCore
 mockito-kotlin = { module = "org.mockito:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- create domain model and repository for app settings
- use DataStore for persisting settings
- inject `SettingsRepository` with Hilt
- add `SettingsViewModel` and update Settings screen with currency selector
- update MainActivity and gradle configs

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.11.0-alpha09', apply: false] was not found)*