### PR TITLE
Add semantic versioning and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
-## [1.0.0] - 2025-05-18
+## [0.0.1] - 2025-05-18
 ### Added
 - Account selector for new transactions. 'From' and 'To' fields now open a list of accounts.
 - Users can still input merchant names directly in the transaction screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
-- Added account selector for new transactions. 'From' and 'To' fields now open a list of accounts.
+
+## [1.0.0] - 2025-05-18
+### Added
+- Account selector for new transactions. 'From' and 'To' fields now open a list of accounts.
 - Users can still input merchant names directly in the transaction screen.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,12 +13,17 @@ android {
     namespace = "dev.pandesal.sbp"
     compileSdk = 36
 
+    val versionMajor: Int by project
+    val versionMinor: Int by project
+    val versionPatch: Int by project
+    val computedVersionCode = versionMajor * 10000 + versionMinor * 100 + versionPatch
+
     defaultConfig {
         applicationId = "dev.pandesal.sbp"
         minSdk = 26
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = computedVersionCode
+        versionName = "$versionMajor.$versionMinor.$versionPatch"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+versionMajor=1
+versionMinor=0
+versionPatch=0

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,6 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-versionMajor=1
+versionMajor=0
 versionMinor=0
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- implement semantic versioning using versionMajor, versionMinor and versionPatch
- expose version numbers in `app/build.gradle.kts`
- create initial CHANGELOG with `1.0.0` entry

## Testing
- `sh ./gradlew tasks --no-daemon` *(fails: No route to host)*