### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS Instructions
+
+These guidelines apply to the entire repository.
+
+- **Commit Messages**: Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
+- **Changelog**: Update `CHANGELOG.md` with any user-facing change under the `Unreleased` section following the Keep a Changelog format.
+- **Testing**: Run `./gradlew test` before committing any code changes.
+- **Nested Instructions**: Check for additional `AGENTS.md` files in subdirectories when modifying files within them.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- AGENTS instructions for AI contributions
+
 
 ## [0.0.1] - 2025-05-18
 ### Added


### PR DESCRIPTION
## Summary
- document repo guidelines in `AGENTS.md`
- log the new instructions in the changelog

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*