### PR TITLE
Add notification center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Notification center with swipe to archive, read status and quick create transaction button
 
 ## [0.0.1] - 2025-05-18
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
@@ -1,0 +1,15 @@
+package dev.pandesal.sbp.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+import java.util.UUID
+
+@Serializable
+@Parcelize
+data class Notification(
+    val id: String = UUID.randomUUID().toString(),
+    val message: String,
+    val isRead: Boolean = false,
+    val canCreateTransaction: Boolean = false
+) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
@@ -36,7 +36,10 @@ class FinancialAppUsageService : Service() {
             } catch (_: Exception) {
                 pkg
             }
-            InAppNotificationCenter.postNotification("Did you transact with $appName?")
+            InAppNotificationCenter.postNotification(
+                message = "Did you transact with $appName?",
+                canCreateTransaction = true
+            )
         }
     }
 

--- a/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
@@ -1,14 +1,26 @@
 package dev.pandesal.sbp.notification
 
+import dev.pandesal.sbp.domain.model.Notification
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 object InAppNotificationCenter {
-    private val _notifications = MutableStateFlow<List<String>>(emptyList())
-    val notifications: StateFlow<List<String>> = _notifications.asStateFlow()
+    private val _notifications = MutableStateFlow<List<Notification>>(emptyList())
+    val notifications: StateFlow<List<Notification>> = _notifications.asStateFlow()
 
-    fun postNotification(message: String) {
-        _notifications.value = _notifications.value + message
+    fun postNotification(message: String, canCreateTransaction: Boolean = false) {
+        _notifications.value =
+            _notifications.value + Notification(message = message, canCreateTransaction = canCreateTransaction)
+    }
+
+    fun markAsRead(id: String) {
+        _notifications.value = _notifications.value.map {
+            if (it.id == id) it.copy(isRead = true) else it
+        }
+    }
+
+    fun archive(id: String) {
+        _notifications.value = _notifications.value.filterNot { it.id == id }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/notification/NotificationTransactionListenerService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/NotificationTransactionListenerService.kt
@@ -11,6 +11,7 @@ import android.service.notification.StatusBarNotification
 import androidx.core.app.NotificationCompat
 import dev.pandesal.sbp.R
 import dev.pandesal.sbp.presentation.MainActivity
+import dev.pandesal.sbp.notification.InAppNotificationCenter
 
 class NotificationTransactionListenerService : NotificationListenerService() {
 
@@ -57,5 +58,10 @@ class NotificationTransactionListenerService : NotificationListenerService() {
             .setAutoCancel(true)
             .build()
         manager.notify(System.currentTimeMillis().toInt(), notify)
+
+        InAppNotificationCenter.postNotification(
+            message = message,
+            canCreateTransaction = true
+        )
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -15,6 +15,7 @@ import dev.pandesal.sbp.presentation.insights.InsightsScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
+import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -33,6 +34,8 @@ sealed class NavigationDestination() {
     data object Transactions : NavigationDestination()
     @Serializable
     data object NewTransaction : NavigationDestination()
+    @Serializable
+    data object Notifications : NavigationDestination()
     @Serializable
     data object Accounts : NavigationDestination()
     @Serializable
@@ -67,6 +70,10 @@ fun AppNavigation(navController: NavHostController) {
 
             dialog<NavigationDestination.NewTransaction> {
                 NewTransactionScreen()
+            }
+
+            composable<NavigationDestination.Notifications> {
+                NotificationCenterScreen()
             }
 
             composable<NavigationDestination.Insights> {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -68,9 +68,7 @@ import dev.pandesal.sbp.domain.model.TransactionType
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.FilterTab
-import dev.pandesal.sbp.presentation.components.NotificationsPopup
 import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
-import dev.pandesal.sbp.notification.InAppNotificationCenter
 import dev.pandesal.sbp.presentation.transactions.TransactionsContent
 import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
 import dev.pandesal.sbp.presentation.transactions.TransactionsViewModel
@@ -88,7 +86,6 @@ fun HomeScreen(
     val navController = LocalNavigationManager.current
     val homeState = viewModel.uiState.collectAsState()
     val transactionsState = transactionsViewModel.uiState.collectAsState()
-    val notificationsState = InAppNotificationCenter.notifications.collectAsState()
 
     if (homeState.value is HomeUiState.Success &&
         transactionsState.value is TransactionsUiState.Success
@@ -107,7 +104,6 @@ fun HomeScreen(
             totalAmount = totalAmount,
             categoryPercentages = categoryPercentages,
             transactions = txState.transactions,
-            notifications = notificationsState.value,
             onViewAllTransactions = {
                 navController.navigate(NavigationDestination.Transactions)
             }
@@ -121,7 +117,6 @@ private fun HomeScreenContent(
     totalAmount: Double,
     categoryPercentages: List<Pair<String, Double>>,
     transactions: List<Transaction>,
-    notifications: List<String> = emptyList(),
     onViewAllTransactions: () -> Unit = {}
 ) {
     val topCategories = categoryPercentages
@@ -156,7 +151,6 @@ private fun HomeScreenContent(
     }
 
     val scope = rememberCoroutineScope()
-    var showNotifications by remember { mutableStateOf(false) }
 
     BottomSheetScaffold(
         containerColor = Color.Transparent,
@@ -258,17 +252,14 @@ private fun HomeScreenContent(
         ) {
             Spacer(Modifier.weight(1f))
             Box(modifier = Modifier.wrapContentSize(Alignment.TopEnd)) {
-                IconButton(onClick = { showNotifications = true }) {
+                IconButton(onClick = {
+                    navController.navigate(NavigationDestination.Notifications)
+                }) {
                     Icon(
                         painterResource(R.drawable.ic_notif),
                         contentDescription = "Notifications"
                     )
                 }
-                NotificationsPopup(
-                    notifications = notifications,
-                    expanded = showNotifications,
-                    onDismissRequest = { showNotifications = false }
-                )
             }
         }
 
@@ -428,7 +419,6 @@ fun HomeScreenPreview() {
                     transactionType = TransactionType.INFLOW
                 )
             ),
-            notifications = listOf("Preview notification")
         )
     }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
@@ -1,0 +1,122 @@
+package dev.pandesal.sbp.presentation.notifications
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.DismissDirection
+import androidx.compose.material3.DismissValue
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SwipeToDismiss
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDismissState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.notification.InAppNotificationCenter
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationCenterScreen() {
+    val navController = LocalNavigationManager.current
+    val notifications by InAppNotificationCenter.notifications.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Notifications") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.navigateUp() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = null)
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            items(notifications, key = { it.id }) { notif ->
+                val dismissState = rememberDismissState(confirmValueChange = {
+                    if (it == DismissValue.DismissedToEnd || it == DismissValue.DismissedToStart) {
+                        InAppNotificationCenter.archive(notif.id)
+                        true
+                    } else {
+                        false
+                    }
+                })
+                SwipeToDismiss(
+                    state = dismissState,
+                    background = {},
+                    directions = setOf(DismissDirection.StartToEnd, DismissDirection.EndToStart)
+                ) {
+                    NotificationItem(
+                        notification = notif,
+                        onMarkRead = { InAppNotificationCenter.markAsRead(notif.id) },
+                        onCreateTransaction = {
+                            InAppNotificationCenter.markAsRead(notif.id)
+                            navController.navigate(dev.pandesal.sbp.presentation.NavigationDestination.NewTransaction)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationItem(
+    notification: dev.pandesal.sbp.domain.model.Notification,
+    onMarkRead: () -> Unit,
+    onCreateTransaction: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (!notification.isRead) {
+                    Box(
+                        Modifier
+                            .padding(end = 8.dp)
+                            .background(color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.small)
+                            .padding(4.dp)
+                    ) {}
+                }
+                Text(notification.message)
+            }
+            if (notification.canCreateTransaction) {
+                TextButton(onClick = onCreateTransaction) {
+                    Text("Add")
+                }
+            }
+        }
+    }
+    onMarkRead()
+}


### PR DESCRIPTION
## Summary
- implement Notification data model and center logic
- allow posting notifications from usage and listener services
- navigate to new NotificationCenterScreen from Home
- create NotificationCenterScreen with swipe to archive and read status
- document changes in CHANGELOG

## Testing
- `./gradlew test` *(fails: No route to host)*