### PR TITLE
Add swipe actions for categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2025-05-18
+### Changed
+- Category groups and categories now use swipe gestures: swipe right to edit and
+  swipe left to delete.
+
+## [0.1.0] - 2025-05-18
 ### Added
 - Skeleton loaders for screens when UI state is `Initial`
 - Notification center with swipe to archive, read status and quick create transaction button
@@ -14,6 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Amount field in new transaction screen now displays the cursor even when zero
   and treats the initial zero as a placeholder.
+- Category groups and categories can now be reordered by long pressing anywhere,
+  with options to edit or delete after long press while the rest of the screen
+  is dimmed.
 
 
 ## [0.0.1] - 2025-05-18

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -25,12 +25,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloseFullscreen
 import androidx.compose.material.icons.filled.Fullscreen
-import androidx.compose.material.icons.rounded.Menu
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -40,6 +40,9 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -64,6 +67,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.domain.model.Category
 import dev.pandesal.sbp.domain.model.CategoryGroup
 import dev.pandesal.sbp.domain.model.CategoryWithBudget
 import dev.pandesal.sbp.extensions.ReorderHapticFeedbackType
@@ -88,6 +92,10 @@ private fun CategoriesListContent(
     onAddBudget: (amount: BigDecimal, categoryId: Int) -> Unit,
     reorderGroup: (from: Int, to: Int) -> Unit,
     reorderCategory: (groupId: Int, from: Int, to: Int) -> Unit,
+    onEditGroup: (CategoryGroup, String) -> Unit,
+    onDeleteGroup: (CategoryGroup) -> Unit,
+    onEditCategory: (Category, String) -> Unit,
+    onDeleteCategory: (Category) -> Unit,
 ) {
     var showNewCategoryGroup by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -116,6 +124,11 @@ private fun CategoriesListContent(
     var showSetBudgetSheet by remember { mutableStateOf(false) }
     var budgetTargetAmount by remember { mutableStateOf(BigDecimal.ZERO) }
 
+    var groupAction by remember { mutableStateOf<CategoryGroup?>(null) }
+    var editGroup by remember { mutableStateOf<CategoryGroup?>(null) }
+    var categoryAction by remember { mutableStateOf<Category?>(null) }
+    var editCategory by remember { mutableStateOf<Category?>(null) }
+
     Column(modifier = Modifier.fillMaxSize()) {
         Row(
             modifier = Modifier
@@ -138,16 +151,33 @@ private fun CategoriesListContent(
                     val interactionSource = remember { MutableInteractionSource() }
                     val childCategories =
                         categoriesWithBudget.filter { it.category.categoryGroupId == item.id }
+                    val dismissState = rememberSwipeToDismissBoxState(confirmValueChange = {
+                        if (it == SwipeToDismissBoxValue.StartToEnd) {
+                            editGroup = item
+                        } else if (it == SwipeToDismissBoxValue.EndToStart) {
+                            groupAction = item
+                        }
+                        false
+                    })
 
-                    Card(
-                        onClick = {},
-                        modifier = Modifier
-                            .wrapContentHeight()
-                            .semantics {
-                                customActions = listOf(
-                                    CustomAccessibilityAction(
-                                        label = "Move Up",
-                                        action = {
+                    SwipeToDismissBox(
+                        state = dismissState,
+                        backgroundContent = {},
+                    ) {
+                        Card(
+                            onClick = {},
+                            modifier = Modifier
+                                .wrapContentHeight()
+                                .draggableHandle(
+                                    onDragStarted = {},
+                                    onDragStopped = {},
+                                    interactionSource = interactionSource,
+                                )
+                                .semantics {
+                                    customActions = listOf(
+                                        CustomAccessibilityAction(
+                                            label = "Move Up",
+                                            action = {
                                             if (index > 0) {
                                                 groupList = groupList.toMutableList().apply {
                                                     add(index - 1, removeAt(index))
@@ -173,8 +203,8 @@ private fun CategoriesListContent(
                                     ),
                                 )
                             },
-                        interactionSource = interactionSource,
-                    ) {
+                            interactionSource = interactionSource,
+                        ) {
                         Row(
                             Modifier.fillMaxSize(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -194,18 +224,7 @@ private fun CategoriesListContent(
                             }) {
                                 Text("Add Category")
                             }
-                            IconButton(
-                                modifier = Modifier
-                                    .draggableHandle(
-                                        onDragStarted = { /* Optionally haptic */ },
-                                        onDragStopped = { /* Optionally haptic */ },
-                                        interactionSource = interactionSource,
-                                    )
-                                    .clearAndSetSemantics { },
-                                onClick = {},
-                            ) {
-                                Icon(Icons.Rounded.Menu, contentDescription = "Reorder")
-                            }
+                            Spacer(Modifier.size(16.dp))
                         }
 
                         ChildListContent(
@@ -216,7 +235,9 @@ private fun CategoriesListContent(
                             },
                             reorderCategory = { from, to ->
                                 reorderCategory(item.id, from, to)
-                            }
+                            },
+                            onEditCategory = { editCategory = it },
+                            onDeleteCategory = { categoryAction = it }
                         )
                     }
                 }
@@ -272,13 +293,78 @@ private fun CategoriesListContent(
             }
         )
     }
+
+    if (groupAction != null) {
+        AlertDialog(
+            onDismissRequest = { groupAction = null },
+            confirmButton = {
+                TextButton(onClick = {
+                    editGroup = groupAction
+                    groupAction = null
+                }) { Text("Edit") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    onDeleteGroup(groupAction!!)
+                    groupAction = null
+                }) { Text("Delete") }
+            }
+        )
+    }
+
+    if (categoryAction != null) {
+        AlertDialog(
+            onDismissRequest = { categoryAction = null },
+            confirmButton = {
+                TextButton(onClick = {
+                    editCategory = categoryAction
+                    categoryAction = null
+                }) { Text("Edit") }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    onDeleteCategory(categoryAction!!)
+                    categoryAction = null
+                }) { Text("Delete") }
+            }
+        )
+    }
+
+    if (editGroup != null) {
+        NewCategoryGroupScreen(
+            sheetState = sheetState,
+            initialName = editGroup!!.name,
+            onSubmit = { name ->
+                onEditGroup(editGroup!!, name)
+                editGroup = null
+            },
+            onCancel = { editGroup = null },
+            onDismissRequest = { editGroup = null }
+        )
+    }
+
+    if (editCategory != null) {
+        NewCategoryScreen(
+            sheetState = newCategorySheetState,
+            groupId = editCategory!!.categoryGroupId,
+            initialName = editCategory!!.name,
+            onSubmit = { name, _ ->
+                onEditCategory(editCategory!!, name)
+                editCategory = null
+            },
+            onCancel = { editCategory = null },
+            onDismissRequest = { editCategory = null }
+        )
+    }
 }
 
 @Composable
 private fun ChildListContent(
     childCategories: List<CategoryWithBudget>,
     onAddBudgetClick: (categoryId: Int) -> Unit,
-    reorderCategory: (from: Int, to: Int) -> Unit
+    reorderCategory: (from: Int, to: Int) -> Unit,
+    onEditCategory: (Category) -> Unit,
+    onDeleteCategory: (Category) -> Unit
 ) {
     var childList by remember { mutableStateOf(childCategories) }
 
@@ -306,18 +392,35 @@ private fun ChildListContent(
             itemsIndexed(childList, key = { _, item -> item.category.id }) { index, item ->
                 ReorderableItem(reorderableLazyCategoriesColumnState, item.category.id) {
                     val interactionSource = remember { MutableInteractionSource() }
+                    val dismissState = rememberSwipeToDismissBoxState(confirmValueChange = {
+                        if (it == SwipeToDismissBoxValue.StartToEnd) {
+                            onEditCategory(item.category)
+                        } else if (it == SwipeToDismissBoxValue.EndToStart) {
+                            onDeleteCategory(item.category)
+                        }
+                        false
+                    })
 
-                    Card(
-                        onClick = {},
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiary),
-                        shape = RoundedCornerShape(16.dp),
-                        modifier = Modifier
-                            .wrapContentHeight()
-                            .semantics {
-                                customActions = listOf(
-                                    CustomAccessibilityAction(
-                                        label = "Move Up",
-                                        action = {
+                    SwipeToDismissBox(
+                        state = dismissState,
+                        backgroundContent = {},
+                    ) {
+                        Card(
+                            onClick = {},
+                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiary),
+                            shape = RoundedCornerShape(16.dp),
+                            modifier = Modifier
+                                .wrapContentHeight()
+                                .draggableHandle(
+                                    onDragStarted = {},
+                                    onDragStopped = {},
+                                    interactionSource = interactionSource,
+                                )
+                                .semantics {
+                                    customActions = listOf(
+                                        CustomAccessibilityAction(
+                                            label = "Move Up",
+                                            action = {
                                             if (index > 0) {
                                                 childList = childList.toMutableList().apply {
                                                     add(index - 1, removeAt(index))
@@ -343,8 +446,8 @@ private fun ChildListContent(
                                     ),
                                 )
                             },
-                        interactionSource = interactionSource,
-                    ) {
+                            interactionSource = interactionSource,
+                        ) {
                         Row(
                             Modifier.fillMaxSize(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -376,18 +479,7 @@ private fun ChildListContent(
                                 }
                             }
 
-                            IconButton(
-                                modifier = Modifier
-                                    .draggableHandle(
-                                        onDragStarted = { /* Optionally haptic */ },
-                                        onDragStopped = { /* Optionally haptic */ },
-                                        interactionSource = interactionSource,
-                                    )
-                                    .clearAndSetSemantics { },
-                                onClick = {},
-                            ) {
-                                Icon(Icons.Rounded.Menu, contentDescription = "Reorder")
-                            }
+                            Spacer(Modifier.size(16.dp))
                         }
                     }
                 }
@@ -491,7 +583,11 @@ fun CategoriesScreen(
                     reorderCategory = { groupId, from, to ->
                         haptic.performHapticFeedback(ReorderHapticFeedbackType.MOVE)
                         viewModel.reorderCategory(from, to, groupId)
-                    }
+                    },
+                    onEditGroup = { group, name -> viewModel.updateCategoryGroup(group, name) },
+                    onDeleteGroup = { viewModel.deleteCategoryGroup(it) },
+                    onEditCategory = { category, name -> viewModel.updateCategory(category, name) },
+                    onDeleteCategory = { viewModel.deleteCategory(it) }
                 )
             }
         ) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesViewModel.kt
@@ -122,5 +122,29 @@ class CategoriesViewModel @Inject constructor(
         }
     }
 
+    fun updateCategoryGroup(group: CategoryGroup, name: String) {
+        viewModelScope.launch {
+            useCase.insertCategoryGroup(group.copy(name = name))
+        }
+    }
+
+    fun deleteCategoryGroup(group: CategoryGroup) {
+        viewModelScope.launch {
+            useCase.deleteCategoryGroup(group)
+        }
+    }
+
+    fun updateCategory(category: Category, name: String) {
+        viewModelScope.launch {
+            useCase.insertCategory(category.copy(name = name))
+        }
+    }
+
+    fun deleteCategory(category: Category) {
+        viewModelScope.launch {
+            useCase.deleteCategory(category)
+        }
+    }
+
 
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryGroupScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryGroupScreen.kt
@@ -25,11 +25,12 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun NewCategoryGroupScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
+    initialName: String = "",
     onSubmit: (String) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
-    var name by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf(initialName) }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
@@ -26,11 +26,12 @@ import androidx.compose.ui.unit.dp
 fun NewCategoryScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
     groupId: Int,
+    initialName: String = "",
     onSubmit: (name: String, groupId: Int) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
-    var name by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf(initialName) }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=0
-versionPatch=1
+versionMinor=2
+versionPatch=0


### PR DESCRIPTION
## Summary
- enable swipe gestures to edit or delete category groups and categories
- remove long-press menu logic
- bump app version to 0.2.0
- document new gestures in the changelog

## Testing
- `./gradlew test` *(fails: could not download Gradle distribution)*