### PR TITLE
Fix new transaction defaults and width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - 2025-05-19
 ### Added
 - Skeleton loaders for screens when UI state is `Initial`
 - Notification center with swipe to archive, read status and quick create transaction button
@@ -12,8 +12,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Pie chart summary and bottom sheet layout for Categories screen
 
 ### Changed
-- Amount field in new transaction screen now displays the cursor even when zero
-  and treats the initial zero as a placeholder.
+- Amount field in new transaction screen now displays the cursor even when zero and treats the initial zero as a placeholder.
+
+### Fixed
+- Default transaction type selection is now Outflow.
+- New transaction dialog now fills the entire screen width.
 
 
 ## [0.0.1] - 2025-05-18

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
 import dev.pandesal.sbp.domain.model.Transaction
@@ -68,7 +69,9 @@ fun AppNavigation(navController: NavHostController) {
                 TransactionsScreen()
             }
 
-            dialog<NavigationDestination.NewTransaction> {
+            dialog<NavigationDestination.NewTransaction>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+            ) {
                 NewTransactionScreen()
             }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -135,7 +135,9 @@ private fun NewTransactionScreen(
 
     // Transaction Type Tabs
     val transactionTypes = listOf(TransactionType.INFLOW, TransactionType.OUTFLOW, TransactionType.TRANSFER)
-    val selectedIndex = transactionTypes.indexOf(transaction.transactionType)
+    var selectedIndex by remember(transaction.transactionType) {
+        mutableIntStateOf(transactionTypes.indexOf(transaction.transactionType))
+    }
 
     Column(
         modifier = Modifier
@@ -515,7 +517,6 @@ private fun NewTransactionScreen(
             },
             content = {
                 val options = listOf("Inflow", "Outflow", "Transfer")
-                var selectedIndex by remember { mutableIntStateOf(0) }
 
                 Row(
                     Modifier.padding(horizontal = 8.dp),

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=0
-versionPatch=1
+versionMinor=1
+versionPatch=0


### PR DESCRIPTION
## Summary
- default new transactions to outflow and remember updates
- make new transaction dialog fill the whole screen
- bump version to 0.1.0
- update changelog

## Testing
- `bash ./gradlew test --no-daemon` *(fails: Permission denied / download gradle)*