### PR TITLE
Fix new category group name display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2025-05-18
+### Changed
+- New category sheet now displays the selected category group name instead of its ID.
+
 ## [0.2.3] - 2025-05-18
 ### Fixed
 - Outflow transactions on the home screen are now shown with a red negative amount

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -102,6 +102,7 @@ private fun CategoriesListContent(
 
     var showNewCategorySheet by remember { mutableStateOf(false) }
     var selectedGroupId by remember { mutableStateOf<Int?>(null) }
+    var selectedGroupName by remember { mutableStateOf<String?>(null) }
     var selectedCategoryId by remember { mutableStateOf<Int?>(null) }
     val newCategorySheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -220,6 +221,7 @@ private fun CategoriesListContent(
                                 Spacer(Modifier.weight(1f))
                                 TextButton(onClick = {
                                     selectedGroupId = item.id
+                                    selectedGroupName = item.name
                                     showNewCategorySheet = true
                                 }) {
                                     Text("Add Category")
@@ -261,18 +263,22 @@ private fun CategoriesListContent(
             NewCategoryScreen(
                 sheetState = newCategorySheetState,
                 groupId = selectedGroupId!!,
+                groupName = selectedGroupName ?: "",
                 onSubmit = { name, groupId ->
                     onAddCategory(name, groupId)
                     showNewCategorySheet = false
                     selectedGroupId = null
+                    selectedGroupName = null
                 },
                 onCancel = {
                     showNewCategorySheet = false
                     selectedGroupId = null
+                    selectedGroupName = null
                 },
                 onDismissRequest = {
                     showNewCategorySheet = false
                     selectedGroupId = null
+                    selectedGroupName = null
                 }
             )
         }
@@ -347,6 +353,7 @@ private fun CategoriesListContent(
             NewCategoryScreen(
                 sheetState = newCategorySheetState,
                 groupId = editCategory!!.categoryGroupId,
+                groupName = groupList.firstOrNull { it.id == editCategory!!.categoryGroupId }?.name ?: "",
                 initialName = editCategory!!.name,
                 onSubmit = { name, _ ->
                     onEditCategory(editCategory!!, name)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 fun NewCategoryScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
     groupId: Int,
+    groupName: String,
     initialName: String = "",
     onSubmit: (name: String, groupId: Int) -> Unit,
     onCancel: () -> Unit,
@@ -43,7 +44,7 @@ fun NewCategoryScreen(
                 .padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text(text = "Add Category to Group ID: $groupId")
+            Text(text = "Add Category to Group: $groupName")
 
             OutlinedTextField(
                 value = name,

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=2
-versionPatch=3
+versionPatch=4


### PR DESCRIPTION
## Summary
- show selected group name when creating or editing a category
- bump version to 0.2.5
- document change in CHANGELOG

## Testing
- `./gradlew test` *(fails: No route to host)*