### PR TITLE
Add inflow defaults and seed database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-05-19
+### Added
+- Seeded an **Inflow** category group with default categories such as Salary and Allowance.
+- New transactions default to the **Salary** category when the transaction type is Inflow.
+
 ## [0.2.3] - 2025-05-18
 ### Fixed
 - Outflow transactions on the home screen are now shown with a red negative amount

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp.data.local
 
 import android.content.Context
 import androidx.compose.ui.input.key.type
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
@@ -47,6 +48,32 @@ abstract class SbpDatabase : RoomDatabase(), DatabaseDaos {
                         SbpDatabase::class.java,
                         "sbp_database"
                     )
+                        .addCallback(object : RoomDatabase.Callback() {
+                            override fun onCreate(db: SupportSQLiteDatabase) {
+                                super.onCreate(db)
+                                db.execSQL(
+                                    "INSERT INTO category_groups (id, name, description, icon, weight, isFavorite, isArchived, isSystemSet) VALUES (1, 'Inflow', '', '', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (1, 'Salary', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (2, 'Allowance', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (3, 'Sales / Business Income', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (4, 'Capital Gains', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (5, 'Refund', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (6, 'Gift', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
+                                )
+                            }
+                        })
                         .fallbackToDestructiveMigration()
                         .build()
                     INSTANCE = instance

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -97,13 +97,26 @@ class NewTransactionsViewModel @Inject constructor(
     }
 
     fun updateTransaction(newTransaction: Transaction) {
-        val newTransaction = newTransaction.copy(
+        var newTransaction = newTransaction.copy(
             name = if ((_transaction.value.category != newTransaction.category || newTransaction.name.trim().isEmpty()) && newTransaction.category != null) {
                 newTransaction.category.name + " " + "Payment"
             } else {
                 newTransaction.name
             }
         )
+
+        if (_transaction.value.transactionType != newTransaction.transactionType &&
+            newTransaction.transactionType == TransactionType.INFLOW
+        ) {
+            val current = _uiState.value
+            if (current is NewTransactionUiState.Success) {
+                val salary = current.groupedCategories.values.flatten()
+                    .firstOrNull { it.name.equals("Salary", ignoreCase = true) }
+                if (salary != null) {
+                    newTransaction = newTransaction.copy(category = salary)
+                }
+            }
+        }
 
         if (_transaction.value.category?.id != newTransaction.category?.id && newTransaction.category != null) {
             loadMerchants(newTransaction.category.id.toString())

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=2
-versionPatch=3
+versionMinor=3
+versionPatch=0


### PR DESCRIPTION
## Summary
- seed database with Inflow category group and basic categories
- default new inflow transactions to Salary category
- bump version to 0.3.0

## Testing
- `./gradlew test` *(fails: No route to host)*