### PR TITLE
fix: allow inflow categories selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.1] - 2025-05-21
+### Fixed
+- Inflow categories were filtered out and could not be selected on the New Transaction screen.
 ## [0.5.0] - 2025-05-20
 ### Added
 - Prompt to add default outflow categories when none exist.

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/CategoryUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/CategoryUseCase.kt
@@ -35,9 +35,7 @@ class CategoryUseCase @Inject constructor(
 
     // Categories
     fun getCategories(): Flow<List<Category>> =
-        repository.getCategories().map { list ->
-            list.filter { it.categoryType != TransactionType.INFLOW }
-        }
+        repository.getCategories()
 
     fun getCategoriesWithLatestBudget(): Flow<List<CategoryWithBudget>> =
         repository.getCategoriesWithLatestBudget().map { list ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=5
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- include inflow categories when fetching categories
- bump version to 0.5.1
- document fix in CHANGELOG

## Testing
- `./gradlew test` *(fails: No route to host while downloading gradle)*