### PR TITLE
fix(accounts): correct total alignment and add squiggly divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.5.1] - 2025-05-21
+### Fixed
+- Accounts total now calculates correctly.
+- Total amount text aligns with the add account button.
+### Changed
+- Added a squiggly divider for a more playful Accounts screen.
 ## [0.5.0] - 2025-05-20
 ### Added
 - Prompt to add default outflow categories when none exist.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -6,10 +6,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.CreditCard
@@ -29,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -37,7 +38,7 @@ import dev.pandesal.sbp.extensions.format
 import dev.pandesal.sbp.extensions.label
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.NavigationDestination
-import java.math.BigDecimal
+import dev.pandesal.sbp.presentation.components.SquigglyDivider
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -75,7 +76,7 @@ private fun AccountsContent(
     onAddWallet: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val totalValue = accounts.fold(BigDecimal.ZERO) { acc, account -> acc + account.balance }
+    val totalValue = accounts.sumOf { it.balance.toDouble() }
 
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -87,16 +88,21 @@ private fun AccountsContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(bottom = 8.dp),
-                horizontalArrangement = Arrangement.End
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
+                Text(
+                    text = "Total: ₱${'$'}{totalValue.format()}",
+                    style = MaterialTheme.typography.titleMedium,
+                )
                 Button(onClick = onAddWallet) { Text("Add Wallet") }
             }
         }
         item {
-            Text(
-                text = "Total: ₱${'$'}{totalValue.format()}",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(bottom = 8.dp)
+            SquigglyDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(16.dp)
             )
         }
         items(accounts, key = { it.id }) { account ->

--- a/app/src/main/java/dev/pandesal/sbp/presentation/components/SquigglyDivider.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/components/SquigglyDivider.kt
@@ -1,0 +1,44 @@
+package dev.pandesal.sbp.presentation.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.StrokeCap
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SquigglyDivider(
+    modifier: Modifier = Modifier,
+    color: Color = Color.LightGray,
+    amplitude: Float = 8f,
+    wavelength: Float = 40f
+) {
+    Canvas(modifier = modifier) {
+        val path = Path()
+        val midY = size.height / 2f
+        var x = 0f
+        while (x <= size.width) {
+            path.quadraticBezierTo(
+                x + wavelength / 4f,
+                midY - amplitude,
+                x + wavelength / 2f,
+                midY
+            )
+            path.quadraticBezierTo(
+                x + wavelength * 3f / 4f,
+                midY + amplitude,
+                x + wavelength,
+                midY
+            )
+            x += wavelength
+        }
+        drawPath(
+            path = path,
+            color = color,
+            style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round)
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=5
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- fix accounts total calculation and alignment
- add squiggly divider for fun UI
- bump version to 0.5.1

## Testing
- `./gradlew test` *(fails: No route to host)*