### PR TITLE
Add initial balance to account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-05-21
+### Added
+- Option to set an initial balance when adding an account.
+- Currency selection now uses a dropdown like in Settings.
+
 
 ## [0.8.0] - 2025-05-21
 ### Added
@@ -103,6 +108,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 - Outflow transactions on the home screen are now shown with a red negative amount
+
+
+## [0.9.0] - 2025-05-21
+### Added
+- Option to set an initial balance when adding an account.
+- Currency selection now uses a dropdown like in Settings.
 
 ## [0.0.1] - 2025-05-18
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,9 +30,19 @@ class AccountsViewModel @Inject constructor(
         }
     }
 
-    fun addAccount(name: String, type: AccountType, currency: String = "PHP") {
+    fun addAccount(
+        name: String,
+        type: AccountType,
+        initialBalance: BigDecimal = BigDecimal.ZERO,
+        currency: String = "PHP"
+    ) {
         viewModelScope.launch {
-            val account = Account(name = name, type = type, currency = currency)
+            val account = Account(
+                name = name,
+                type = type,
+                balance = initialBalance,
+                currency = currency
+            )
             useCase.insertAccount(account)
         }
     }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
@@ -29,8 +29,8 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ListItem
-import androidx.compose.ui.text.input.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import java.math.BigDecimal
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
@@ -26,6 +26,13 @@ import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ListItem
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+import java.math.BigDecimal
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -48,7 +55,9 @@ fun NewAccountScreen(
     val navigationManager = LocalNavigationManager.current
 
     NewAccountScreen(
-        onSubmit = { name, type, currency -> viewModel.addAccount(name, type, currency) },
+        onSubmit = { name, type, balance, currency ->
+            viewModel.addAccount(name, type, balance, currency)
+        },
         onCancel = { },
         onDismissRequest = {
             navigationManager.navigateUp()
@@ -60,13 +69,15 @@ fun NewAccountScreen(
 @Composable
 private fun NewAccountScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
-    onSubmit: (name: String, type: AccountType, currency: String) -> Unit,
+    onSubmit: (name: String, type: AccountType, balance: BigDecimal, currency: String) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     var name by remember { mutableStateOf("") }
     var selectedType by remember { mutableStateOf(AccountType.CASH_WALLET) }
     var currency by remember { mutableStateOf("PHP") }
+    var balance by remember { mutableStateOf(BigDecimal.ZERO) }
+    var showCurrencySheet by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -109,10 +120,25 @@ private fun NewAccountScreen(
                 )
 
                 OutlinedTextField(
+                    value = balance.toString(),
+                    onValueChange = { balance = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
+                    label = { Text("Initial Balance") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true
+                )
+
+                OutlinedTextField(
                     value = currency,
-                    onValueChange = { currency = it },
+                    onValueChange = { },
                     label = { Text("Currency") },
-                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                        .clickable { showCurrencySheet = true },
+                    readOnly = true
                 )
 
                 Row(
@@ -144,6 +170,27 @@ private fun NewAccountScreen(
             }
         }
 
+        if (showCurrencySheet) {
+            val currencySheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val currencies = listOf("PHP", "USD", "EUR", "JPY")
+            ModalBottomSheet(
+                onDismissRequest = { showCurrencySheet = false },
+                sheetState = currencySheetState
+            ) {
+                LazyColumn(modifier = Modifier.padding(16.dp)) {
+                    items(currencies) { currencyOption ->
+                        ListItem(
+                            headlineContent = { Text(currencyOption) },
+                            modifier = Modifier.clickable {
+                                currency = currencyOption
+                                showCurrencySheet = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(16.dp))
 
         HorizontalFloatingToolbar(
@@ -152,7 +199,7 @@ private fun NewAccountScreen(
             floatingActionButton = {
                 FloatingToolbarDefaults.VibrantFloatingActionButton(
                     onClick = {
-                        onSubmit(name, selectedType, currency)
+                        onSubmit(name, selectedType, balance, currency)
                         onDismissRequest()
                     }
                 ) {

--- a/app/src/test/java/dev/pandesal/sbp/AccountsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/AccountsViewModelTest.kt
@@ -3,6 +3,7 @@ package dev.pandesal.sbp
 import dev.pandesal.sbp.domain.model.Account
 import dev.pandesal.sbp.domain.model.AccountType
 import dev.pandesal.sbp.domain.usecase.AccountUseCase
+import java.math.BigDecimal
 import dev.pandesal.sbp.fakes.FakeAccountRepository
 import dev.pandesal.sbp.presentation.accounts.AccountsUiState
 import dev.pandesal.sbp.presentation.accounts.AccountsViewModel
@@ -37,9 +38,10 @@ class AccountsViewModelTest {
     @Test
     fun addAccountInsertsAccount() = runTest {
         val vm = AccountsViewModel(useCase)
-        vm.addAccount("B", AccountType.BANK_ACCOUNT, "PHP")
+        vm.addAccount("B", AccountType.BANK_ACCOUNT, BigDecimal.TEN, "PHP")
         advanceUntilIdle()
         assertEquals(1, repository.insertedAccounts.size)
         assertEquals("B", repository.insertedAccounts[0].name)
+        assertEquals(BigDecimal.TEN, repository.insertedAccounts[0].balance)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
  [versions]
-agp = "8.11.0-alpha09"
+agp = "8.11.0-alpha10"
 kotlin = "2.1.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary
- allow specifying initial balance when adding an account
- use dropdown currency selector on the add account sheet
- bump version to 0.9.0
- update tests

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.11.0-alpha09', apply: false] was not found)*