### PR TITLE
Add loan account type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,35 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.10.0] - 2025-05-21
+## [0.10.0] - 2025-05-19
 ### Added
-- Option to set an initial balance when adding an account.
-- Currency selection now uses a dropdown like in Settings.
-
-## [0.9.0] - 2025-05-21
+- Loan account type with contract value and monthly payment fields.
+- Automatic liability category creation for loans.
+- 
+## [0.9.0] - 2025-05-18
 ### Added
 - Recurring transaction options can now be selected directly from the New Transaction screen.
 
-## [0.8.0] - 2025-05-21
+
+## [0.8.0] - 2025-05-18
 ### Added
 - Graph bars now have rounded edges and display a popup with budget or net worth details when tapped.
 ### Fixed
 - Insights screen no longer crashes when data is missing.
 
-## [0.7.0] - 2025-05-21
+## [0.7.0] - 2025-05-18
 ### Added
 - Basic screen for setting recurring transactions with options for Monthly, Weekly, Daily and after cutoff date.
 - Access recurring transaction setup from the New Transaction screen.
 
-## [0.6.0] - 2025-05-21
+## [0.6.0] - 2025-05-18
 ### Added
 - Edit mode toggle on Categories screen with edit and delete buttons per group and category.
 - Budgets can now be edited from the Categories screen.
 - Budgets now store their currency alongside allocation data.
 - Currency is now stored for each account in the database.
 
-## [0.5.1] - 2025-05-21
+## [0.5.1] - 2025-05-18
 ### Fixed
 - Accounts total now calculates correctly.
 - Total amount text aligns with the add account button.
@@ -42,29 +43,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 - Added a squiggly divider for a more playful Accounts screen.
 
-## [0.5.0] - 2025-05-20
+## [0.5.0] - 2025-0518
 ### Added
 - Prompt to add default outflow categories when none exist.
 ### Changed
 - Inflow categories no longer appear in transaction or category lists and are ignored in budgets.
 
-## [0.4.0] - 2025-05-19
+## [0.4.0] - 2025-05-18
 ### Changed
 - New transaction screen elements animate sequentially when opening.
 
-## [0.3.2] - 2025-05-19
+## [0.3.2] - 2025-05-18
 ### Fixed
 - Pie chart now renders correctly in the Categories screen.
 
-## [0.3.1] - 2025-05-19
+## [0.3.1] - 2025-05-18
 ### Changed
 - Moved "Add Category Group" button to the sheet handle area on Categories screen
 
-## [0.3.1] - 2025-05-20
+## [0.3.1] - 2025-0518
 ### Changed
 - Moved "Add Wallet" button to the top of the Accounts screen so bottom controls no longer overlap.
 
-## [0.3.0] - 2025-05-19
+## [0.3.0] - 2025-05-18
 ### Added
 - Seeded an **Inflow** category group with default categories such as Salary and Allowance.
 - New transactions default to the **Salary** category when the transaction type is Inflow.
@@ -85,7 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - Unit tests for ViewModels
 
-## [0.2.1] - 2025-05-19
+## [0.2.1] - 2025-05-18
 ### Fixed
 - Default transaction type selection is now Outflow.
 - New transaction dialog now fills the entire screen width.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,12 +112,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 - Outflow transactions on the home screen are now shown with a red negative amount
 
-
-## [0.9.0] - 2025-05-21
-### Added
-- Option to set an initial balance when adding an account.
-- Currency selection now uses a dropdown like in Settings.
-
 ## [0.0.1] - 2025-05-18
 ### Added
 - Initial Changelog file

--- a/app/src/main/java/dev/pandesal/sbp/data/local/Account.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/Account.kt
@@ -12,7 +12,11 @@ data class AccountEntity(
     val name: String,
     val type: String,
     val balance: BigDecimal = BigDecimal.ZERO,
-    val currency: String = "PHP"
+    val currency: String = "PHP",
+    val contractValue: BigDecimal? = null,
+    val monthlyPayment: BigDecimal? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
 )
 
 fun AccountEntity.toDomainModel(): Account {
@@ -21,7 +25,11 @@ fun AccountEntity.toDomainModel(): Account {
         name = name,
         type = AccountType.valueOf(type),
         balance = balance,
-        currency = currency
+        currency = currency,
+        contractValue = contractValue,
+        monthlyPayment = monthlyPayment,
+        startDate = startDate,
+        endDate = endDate,
     )
 }
 
@@ -31,6 +39,10 @@ fun Account.toEntity(): AccountEntity {
         name = name,
         type = type.name,
         balance = balance,
-        currency = currency
+        currency = currency,
+        contractValue = contractValue,
+        monthlyPayment = monthlyPayment,
+        startDate = startDate,
+        endDate = endDate,
     )
 }

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -23,7 +23,7 @@ import java.math.BigDecimal
         MonthlyBudgetEntity::class,
         TransactionEntity::class,
         AccountEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(BigDecimalConverter::class, ListStringConverter::class)

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Account.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Account.kt
@@ -14,7 +14,13 @@ data class Account(
     val type: AccountType,
     @Serializable(with = BigDecimalSerializer::class)
     val balance: BigDecimal = BigDecimal.ZERO,
-    val currency: String = "PHP"
+    val currency: String = "PHP",
+    @Serializable(with = BigDecimalSerializer::class)
+    val contractValue: BigDecimal? = null,
+    @Serializable(with = BigDecimalSerializer::class)
+    val monthlyPayment: BigDecimal? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
 ) : Parcelable
 
 @Serializable
@@ -23,5 +29,6 @@ enum class AccountType : Parcelable {
     CASH_WALLET,
     MOBILE_DIGITAL_WALLET,
     BANK_ACCOUNT,
-    CREDIT_CARD
+    CREDIT_CARD,
+    LOAN,
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.CreditCard
+import androidx.compose.material.icons.outlined.AttachMoney
 import androidx.compose.material.icons.outlined.Wallet
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Button
@@ -128,4 +129,5 @@ private fun getAccountIcon(type: AccountType): ImageVector = when (type) {
     AccountType.MOBILE_DIGITAL_WALLET -> Icons.Outlined.AccountBalanceWallet
     AccountType.BANK_ACCOUNT -> Icons.Outlined.AccountBalance
     AccountType.CREDIT_CARD -> Icons.Outlined.CreditCard
+    AccountType.LOAN -> Icons.Outlined.AttachMoney
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -50,23 +50,20 @@ fun AccountsScreen(
     var showNew by remember { mutableStateOf(false) }
     val navigationManager = LocalNavigationManager.current
 
-    Scaffold { padding ->
-        when (val state = uiState) {
-            is AccountsUiState.Loading -> {
-                Text("Loading...", modifier = Modifier.padding(16.dp))
-            }
-            is AccountsUiState.Success -> {
-                AccountsContent(
-                    accounts = state.accounts,
-                    onAddWallet = {
-                        navigationManager.navigate(NavigationDestination.NewAccount)
-                    },
-                    modifier = Modifier.padding(padding)
-                )
-            }
-            is AccountsUiState.Error -> {
-                Text(state.message, color = MaterialTheme.colorScheme.error)
-            }
+    when (val state = uiState) {
+        is AccountsUiState.Loading -> {
+            Text("Loading...", modifier = Modifier.padding(16.dp))
+        }
+        is AccountsUiState.Success -> {
+            AccountsContent(
+                accounts = state.accounts,
+                onAddWallet = {
+                    navigationManager.navigate(NavigationDestination.NewAccount)
+                },
+            )
+        }
+        is AccountsUiState.Error -> {
+            Text(state.message, color = MaterialTheme.colorScheme.error)
         }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
@@ -56,8 +56,8 @@ class AccountsViewModel @Inject constructor(
             val account = Account(
                 name = name,
                 type = type,
-                currency = currency,
                 balance = initialBalance,
+                currency = currency,
                 contractValue = contract,
                 monthlyPayment = monthly,
                 startDate = if (contract != null && monthly != null) start else null,

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
@@ -5,17 +5,23 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.pandesal.sbp.domain.model.Account
 import dev.pandesal.sbp.domain.model.AccountType
+import dev.pandesal.sbp.domain.model.Category
+import dev.pandesal.sbp.domain.model.CategoryGroup
+import dev.pandesal.sbp.domain.model.TransactionType
 import dev.pandesal.sbp.domain.usecase.AccountUseCase
+import dev.pandesal.sbp.domain.usecase.CategoryUseCase
+import java.math.BigDecimal
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountsViewModel @Inject constructor(
-    private val useCase: AccountUseCase
+    private val useCase: AccountUseCase,
+    private val categoryUseCase: CategoryUseCase
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<AccountsUiState> =
@@ -34,16 +40,44 @@ class AccountsViewModel @Inject constructor(
         name: String,
         type: AccountType,
         initialBalance: BigDecimal = BigDecimal.ZERO,
-        currency: String = "PHP"
+        currency: String = "PHP",
+        contractValue: String? = null,
+        monthlyPayment: String? = null,
     ) {
         viewModelScope.launch {
+            val contract = contractValue?.takeIf { it.isNotBlank() }?.let { BigDecimal(it) }
+            val monthly = monthlyPayment?.takeIf { it.isNotBlank() }?.let { BigDecimal(it) }
+            val start = LocalDate.now().toString()
+            val end = if (contract != null && monthly != null && monthly > BigDecimal.ZERO) {
+                val months = contract.divide(monthly, 0, java.math.RoundingMode.CEILING).toLong()
+                LocalDate.now().plusMonths(months).toString()
+            } else null
+
             val account = Account(
                 name = name,
                 type = type,
+                currency = currency,
                 balance = initialBalance,
-                currency = currency
+                contractValue = contract,
+                monthlyPayment = monthly,
+                startDate = if (contract != null && monthly != null) start else null,
+                endDate = end
             )
             useCase.insertAccount(account)
+
+            if (type == AccountType.LOAN) {
+                categoryUseCase.insertCategoryGroup(CategoryGroup(id = 20, name = "Liabilities", description = "", icon = ""))
+                categoryUseCase.insertCategory(
+                    Category(
+                        name = name,
+                        description = "Loan Payment",
+                        icon = "",
+                        categoryGroupId = 20,
+                        categoryType = TransactionType.OUTFLOW,
+                        weight = 0,
+                    )
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
@@ -55,8 +55,8 @@ fun NewAccountScreen(
     val navigationManager = LocalNavigationManager.current
 
     NewAccountScreen(
-        onSubmit = { name, type, balance, currency ->
-            viewModel.addAccount(name, type, balance, currency)
+        onSubmit = { name, type, balance, currency, contractValue, monthlyPayment ->
+            viewModel.addAccount(name, type, currency, contractValue, monthlyPayment)
         },
         onCancel = { },
         onDismissRequest = {
@@ -69,13 +69,15 @@ fun NewAccountScreen(
 @Composable
 private fun NewAccountScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
-    onSubmit: (name: String, type: AccountType, balance: BigDecimal, currency: String) -> Unit,
+    onSubmit: (name: String, type: AccountType, balance: BigDecimal, currency: String, contractValue: String?, monthlyPayment: String?) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     var name by remember { mutableStateOf("") }
     var selectedType by remember { mutableStateOf(AccountType.CASH_WALLET) }
     var currency by remember { mutableStateOf("PHP") }
+    var contractValue by remember { mutableStateOf("") }
+    var monthlyPayment by remember { mutableStateOf("") }
     var balance by remember { mutableStateOf(BigDecimal.ZERO) }
     var showCurrencySheet by remember { mutableStateOf(false) }
 
@@ -141,6 +143,21 @@ private fun NewAccountScreen(
                     readOnly = true
                 )
 
+                if (selectedType == AccountType.LOAN) {
+                    OutlinedTextField(
+                        value = contractValue,
+                        onValueChange = { contractValue = it },
+                        label = { Text("Total Contract Value") },
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
+                    )
+                    OutlinedTextField(
+                        value = monthlyPayment,
+                        onValueChange = { monthlyPayment = it },
+                        label = { Text("Monthly Payment") },
+                        modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
+                    )
+                }
+
                 Row(
                     modifier = Modifier
                         .padding(top = 16.dp)
@@ -199,7 +216,7 @@ private fun NewAccountScreen(
             floatingActionButton = {
                 FloatingToolbarDefaults.VibrantFloatingActionButton(
                     onClick = {
-                        onSubmit(name, selectedType, balance, currency)
+                        onSubmit(name, selectedType, balance, currency, contractValue.ifBlank { null }, monthlyPayment.ifBlank { null })
                         onDismissRequest()
                     }
                 ) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
@@ -56,7 +56,7 @@ fun NewAccountScreen(
 
     NewAccountScreen(
         onSubmit = { name, type, balance, currency, contractValue, monthlyPayment ->
-            viewModel.addAccount(name, type, currency, contractValue, monthlyPayment)
+            viewModel.addAccount(name, type, balance, currency, contractValue, monthlyPayment)
         },
         onCancel = { },
         onDismissRequest = {

--- a/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
@@ -11,5 +11,6 @@ class AccountTypeExtensionsTest {
         assertEquals("Mobile digital wallet", AccountType.MOBILE_DIGITAL_WALLET.label())
         assertEquals("Bank account", AccountType.BANK_ACCOUNT.label())
         assertEquals("Credit card", AccountType.CREDIT_CARD.label())
+        assertEquals("Loan", AccountType.LOAN.label())
     }
 }


### PR DESCRIPTION
## Summary
- add `LOAN` account type with contract value & payment fields
- automatically create liability category for new loans
- bump version to 0.9.0

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.11.0-alpha09', apply: false] was not found)*