### PR TITLE
Add Notification Center sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-05-21
+### Added
+- Notification Center now shows sections for **All notifications**, **Upcoming Bills Reminder**, and **Transaction Suggestions**.
 
 ## [0.8.0] - 2025-05-21
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
@@ -5,11 +5,18 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
+enum class NotificationType {
+    GENERAL,
+    BILL_REMINDER,
+    TRANSACTION_SUGGESTION
+}
+
 @Serializable
 @Parcelize
 data class Notification(
     val id: String = UUID.randomUUID().toString(),
     val message: String,
+    val type: NotificationType = NotificationType.GENERAL,
     val isRead: Boolean = false,
     val canCreateTransaction: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
@@ -6,6 +6,8 @@ import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
+import dev.pandesal.sbp.domain.model.NotificationType
+import dev.pandesal.sbp.notification.InAppNotificationCenter
 
 class FinancialAppUsageService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -38,6 +40,7 @@ class FinancialAppUsageService : Service() {
             }
             InAppNotificationCenter.postNotification(
                 message = "Did you transact with $appName?",
+                type = NotificationType.TRANSACTION_SUGGESTION,
                 canCreateTransaction = true
             )
         }

--- a/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
@@ -1,6 +1,7 @@
 package dev.pandesal.sbp.notification
 
 import dev.pandesal.sbp.domain.model.Notification
+import dev.pandesal.sbp.domain.model.NotificationType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -9,9 +10,17 @@ object InAppNotificationCenter {
     private val _notifications = MutableStateFlow<List<Notification>>(emptyList())
     val notifications: StateFlow<List<Notification>> = _notifications.asStateFlow()
 
-    fun postNotification(message: String, canCreateTransaction: Boolean = false) {
+    fun postNotification(
+        message: String,
+        type: NotificationType = NotificationType.GENERAL,
+        canCreateTransaction: Boolean = false
+    ) {
         _notifications.value =
-            _notifications.value + Notification(message = message, canCreateTransaction = canCreateTransaction)
+            _notifications.value + Notification(
+                message = message,
+                type = type,
+                canCreateTransaction = canCreateTransaction
+            )
     }
 
     fun markAsRead(id: String) {

--- a/app/src/main/java/dev/pandesal/sbp/notification/NotificationTransactionListenerService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/NotificationTransactionListenerService.kt
@@ -12,6 +12,7 @@ import androidx.core.app.NotificationCompat
 import dev.pandesal.sbp.R
 import dev.pandesal.sbp.presentation.MainActivity
 import dev.pandesal.sbp.notification.InAppNotificationCenter
+import dev.pandesal.sbp.domain.model.NotificationType
 
 class NotificationTransactionListenerService : NotificationListenerService() {
 
@@ -61,6 +62,7 @@ class NotificationTransactionListenerService : NotificationListenerService() {
 
         InAppNotificationCenter.postNotification(
             message = message,
+            type = NotificationType.TRANSACTION_SUGGESTION,
             canCreateTransaction = true
         )
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0


### PR DESCRIPTION
## Summary
- add `NotificationType` to categorize notifications
- filter notifications per new tabs
- show Notification Center sections for All notifications, Upcoming Bills Reminder and Transaction Suggestions
- bump version to 0.9.0

## Testing
- `./gradlew test` *(fails: No route to host)*