### PR TITLE
Add editable transaction details screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-05-21
+### Added
+- Transaction details screen with edit and save functionality.
 
 ## [0.8.0] - 2025-05-21
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
+import androidx.navigation.compose.navArgs
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.presentation.categories.CategoriesScreen
 import dev.pandesal.sbp.presentation.accounts.AccountsScreen
@@ -17,6 +18,7 @@ import dev.pandesal.sbp.presentation.insights.InsightsScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTransactionScreen
+import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import kotlinx.serialization.Serializable
@@ -92,6 +94,17 @@ fun AppNavigation(navController: NavHostController) {
                 dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
             ) {
                 NewRecurringTransactionScreen()
+            }
+
+            dialog<NavigationDestination.TransactionDetails>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+            ) { backStackEntry ->
+                val args = backStackEntry.navArgs<NavigationDestination.TransactionDetails>()
+                TransactionDetailsScreen(
+                    transaction = args.transaction,
+                    onDismiss = { navController.navigateUp() },
+                    onSave = { navController.navigateUp() }
+                )
             }
 
             composable<NavigationDestination.Notifications> {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/components/TransactionItem.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/components/TransactionItem.kt
@@ -16,9 +16,12 @@ import dev.pandesal.sbp.domain.model.Transaction
 import java.math.BigDecimal
 
 @Composable
-fun TransactionItem(tx: Transaction) {
+fun TransactionItem(
+    tx: Transaction,
+    modifier: Modifier = Modifier
+) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 2.dp)
     ) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/TransactionsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/TransactionsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.ElevatedFilterChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChipDefaults
@@ -52,7 +53,9 @@ fun TransactionsScreen(
         TransactionsContent(
             state.transactions,
             onNewTransactionClick = { navManager.navigate(NavigationDestination.NewTransaction) },
-            onTransactionClick = { navManager.navigate(NavigationDestination.TransactionDetails) }
+            onTransactionClick = { transaction ->
+                navManager.navigate(NavigationDestination.TransactionDetails(transaction))
+            }
         )
     }
 }
@@ -119,7 +122,10 @@ fun TransactionsContent(
                         })
                 }
                 items(txList) { transaction ->
-                    TransactionItem(transaction)
+                    TransactionItem(
+                        tx = transaction,
+                        modifier = Modifier.clickable { onTransactionClick(transaction) }
+                    )
                 }
 
                 item {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/details/TransactionDetailsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/details/TransactionDetailsScreen.kt
@@ -1,0 +1,66 @@
+package dev.pandesal.sbp.presentation.transactions.details
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.domain.model.Transaction
+import java.math.BigDecimal
+
+@Composable
+fun TransactionDetailsScreen(
+    transaction: Transaction,
+    onDismiss: () -> Unit,
+    onSave: () -> Unit,
+    viewModel: TransactionDetailsViewModel = hiltViewModel()
+) {
+    LaunchedEffect(transaction) { viewModel.setTransaction(transaction) }
+    val txState = viewModel.transaction.collectAsState()
+    val tx = txState.value ?: return
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = tx.name,
+            onValueChange = { viewModel.updateTransaction(tx.copy(name = it)) },
+            label = { Text("Name") }
+        )
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            value = if (tx.amount == BigDecimal.ZERO) "" else tx.amount.toPlainString(),
+            onValueChange = { input ->
+                val newAmount = input.toBigDecimalOrNull() ?: BigDecimal.ZERO
+                viewModel.updateTransaction(tx.copy(amount = newAmount))
+            },
+            label = { Text("Amount") },
+            keyboardOptions = KeyboardOptions(keyboardType = androidx.compose.ui.text.input.KeyboardType.Number)
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp),
+            horizontalArrangement = Arrangement.End
+        ) {
+            OutlinedButton(onClick = onDismiss) { Text("Cancel") }
+            Spacer(Modifier.padding(4.dp))
+            Button(onClick = { viewModel.save { if (it) onSave() } }) {
+                Text("Save")
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/details/TransactionDetailsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/details/TransactionDetailsViewModel.kt
@@ -1,0 +1,38 @@
+package dev.pandesal.sbp.presentation.transactions.details
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.usecase.TransactionUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TransactionDetailsViewModel @Inject constructor(
+    private val useCase: TransactionUseCase
+) : ViewModel() {
+
+    private val _transaction = MutableStateFlow<Transaction?>(null)
+    val transaction: StateFlow<Transaction?> = _transaction.asStateFlow()
+
+    fun setTransaction(tx: Transaction) {
+        _transaction.value = tx
+    }
+
+    fun updateTransaction(tx: Transaction) {
+        _transaction.value = tx
+    }
+
+    fun save(onResult: (Boolean) -> Unit = {}) {
+        val tx = _transaction.value ?: return
+        viewModelScope.launch {
+            runCatching { useCase.insert(tx) }
+                .onSuccess { onResult(true) }
+                .onFailure { onResult(false) }
+        }
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/TransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/TransactionDetailsViewModelTest.kt
@@ -1,0 +1,57 @@
+package dev.pandesal.sbp
+
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.usecase.TransactionUseCase
+import dev.pandesal.sbp.fakes.FakeTransactionRepository
+import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransactionDetailsViewModelTest {
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val repository = FakeTransactionRepository()
+    private val useCase = TransactionUseCase(repository)
+
+    @Test
+    fun setTransactionUpdatesState() = runTest {
+        val vm = TransactionDetailsViewModel(useCase)
+        val tx = Transaction(
+            name = "T",
+            amount = BigDecimal.ONE,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            accountId = "",
+            transactionType = TransactionType.OUTFLOW
+        )
+        vm.setTransaction(tx)
+        advanceUntilIdle()
+        assertEquals(tx, vm.transaction.value)
+    }
+
+    @Test
+    fun saveInsertsTransaction() = runTest {
+        val vm = TransactionDetailsViewModel(useCase)
+        val tx = Transaction(
+            name = "T",
+            amount = BigDecimal.ONE,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            accountId = "",
+            transactionType = TransactionType.OUTFLOW
+        )
+        vm.setTransaction(tx)
+        vm.save()
+        advanceUntilIdle()
+        assertEquals(listOf(tx), repository.insertedTransactions)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0


### PR DESCRIPTION
## Summary
- add minor version 0.11.0
- implement transaction details screen with editing
- allow clicking a transaction item to open details
- expose details screen via navigation
- update changelog
- add view model tests for details screen

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] was not found)*