### PR TITLE
feat: add zero-based budgeting summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-05-21
+### Added
+- Zero-based budgeting summary with calculation of unassigned funds on the home screen.
+
 
 ## [0.8.0] - 2025-05-21
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/BudgetSummary.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/BudgetSummary.kt
@@ -1,0 +1,9 @@
+package dev.pandesal.sbp.domain.model
+
+/**
+ * Summary of assigned and unassigned funds for zero-based budgeting.
+ */
+data class BudgetSummary(
+    val assigned: Double,
+    val unassigned: Double
+)

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/ZeroBasedBudgetUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/ZeroBasedBudgetUseCase.kt
@@ -1,0 +1,30 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.BudgetSummary
+import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
+import dev.pandesal.sbp.domain.repository.CategoryRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import java.time.YearMonth
+import javax.inject.Inject
+
+/**
+ * Provides zero-based budgeting summaries for a given month.
+ */
+class ZeroBasedBudgetUseCase @Inject constructor(
+    private val accountRepository: AccountRepositoryInterface,
+    private val categoryRepository: CategoryRepositoryInterface
+) {
+    fun getBudgetSummary(month: YearMonth = YearMonth.now()): Flow<BudgetSummary> =
+        combine(
+            categoryRepository.getMonthlyBudgetsByYearMonth(month),
+            accountRepository.getAccounts()
+        ) { budgets, accounts ->
+            val assigned = budgets.sumOf { it.allocated.toDouble() }
+            val totalFunds = accounts.sumOf { it.balance.toDouble() }
+            BudgetSummary(
+                assigned = assigned,
+                unassigned = totalFunds - assigned
+            )
+        }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -70,6 +70,7 @@ import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.FilterTab
 import dev.pandesal.sbp.presentation.components.NotificationsPopup
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
+import dev.pandesal.sbp.presentation.home.components.BudgetSummaryHeader
 import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
 import dev.pandesal.sbp.presentation.transactions.TransactionsContent
 import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
@@ -110,6 +111,8 @@ fun HomeScreen(
             totalAmount = totalAmount,
             categoryPercentages = categoryPercentages,
             transactions = txState.transactions,
+            unassigned = state.budgetSummary.unassigned,
+            assigned = state.budgetSummary.assigned,
             onViewNotifications = {
                 navController.navigate(NavigationDestination.Notifications)
             }
@@ -123,6 +126,8 @@ private fun HomeScreenContent(
     totalAmount: Double,
     categoryPercentages: List<Pair<String, Double>>,
     transactions: List<Transaction>,
+    unassigned: Double,
+    assigned: Double,
     onViewNotifications: () -> Unit = {}
 ) {
     val topCategories = categoryPercentages
@@ -282,6 +287,7 @@ private fun HomeScreenContent(
                 fontWeight = FontWeight.ExtraBold,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
+            BudgetSummaryHeader(unassigned = unassigned, assigned = assigned)
             val thickStrokeWidth = with(LocalDensity.current) { 8.dp.toPx() }
             val thickStroke =
                 remember(thickStrokeWidth) {
@@ -425,6 +431,8 @@ fun HomeScreenPreview() {
                     transactionType = TransactionType.INFLOW
                 )
             ),
+            unassigned = 0.0,
+            assigned = 0.0,
         )
     }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeUiState.kt
@@ -3,6 +3,7 @@ package dev.pandesal.sbp.presentation.home
 import dev.pandesal.sbp.presentation.model.AccountSummaryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetCategoryUiModel
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
+import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
 
 sealed interface HomeUiState {
     data object Initial : HomeUiState
@@ -10,7 +11,8 @@ sealed interface HomeUiState {
     data class Success(
         val favoriteBudgets: List<BudgetCategoryUiModel>,
         val accounts: List<AccountSummaryUiModel>,
-        val netWorthData: List<NetWorthUiModel>
+        val netWorthData: List<NetWorthUiModel>,
+        val budgetSummary: BudgetSummaryUiModel
     ) : HomeUiState
     data class Error(val errorMessage: String) : HomeUiState
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/BudgetSummaryUiModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/BudgetSummaryUiModel.kt
@@ -1,0 +1,7 @@
+package dev.pandesal.sbp.presentation.model
+
+/** UI model representing budget summary used in the home screen. */
+data class BudgetSummaryUiModel(
+    val assigned: Double,
+    val unassigned: Double
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0


### PR DESCRIPTION
## Summary
- implement ZeroBasedBudgetUseCase and domain model
- show unassigned and assigned funds on home screen
- expose budget summary in HomeViewModel and HomeUiState
- bump version to 0.9.0

## Testing
- `gradle test` *(fails: Plugin not found due to no network)*