### PR TITLE
feat(categories): allow moving items via long press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-05-21
+### Changed
+- Category groups and categories are now movable by long pressing anywhere.
+
 
 ## [0.8.0] - 2025-05-21
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -2,7 +2,6 @@ package dev.pandesal.sbp.presentation.categories
 
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -77,7 +76,9 @@ import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.categories.components.CategoryBudgetPieChart
 import kotlinx.coroutines.launch
 import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.detectReorderAfterLongPress
 import sh.calvin.reorderable.rememberReorderableLazyListState
+import sh.calvin.reorderable.reorderable
 import java.math.BigDecimal
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -128,25 +129,23 @@ private fun CategoriesListContent(
 
     Column(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .reorderable(reorderableLazyGroupsColumnState)
+                .detectReorderAfterLongPress(reorderableLazyGroupsColumnState),
             state = lazyGroupsState,
             contentPadding = PaddingValues(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             itemsIndexed(groupList, key = { _, item -> item.id }) { index, item ->
                 ReorderableItem(reorderableLazyGroupsColumnState, item.id) {
-                    val interactionSource = remember { MutableInteractionSource() }
                     val childCategories =
                         categoriesWithBudget.filter { it.category.categoryGroupId == item.id }
                     Card(
                         onClick = {},
                         modifier = Modifier
                             .wrapContentHeight()
-                            .draggableHandle(
-                                onDragStarted = {},
-                                onDragStopped = {},
-                                interactionSource = interactionSource,
-                            )
+                            .detectReorderAfterLongPress(reorderableLazyGroupsColumnState)
                             .semantics {
                                 customActions = listOf(
                                     CustomAccessibilityAction(
@@ -176,8 +175,7 @@ private fun CategoriesListContent(
                                         }
                                     ),
                                 )
-                            },
-                        interactionSource = interactionSource,
+                            }
                     ) {
                         Row(
                             Modifier.fillMaxSize(),
@@ -342,25 +340,22 @@ private fun ChildListContent(
         LazyColumn(
             modifier = Modifier
                 .height((68 * childList.size).dp + 16.dp)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .reorderable(reorderableLazyCategoriesColumnState)
+                .detectReorderAfterLongPress(reorderableLazyCategoriesColumnState),
             state = lazyCategoriesListState,
             contentPadding = PaddingValues(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             itemsIndexed(childList, key = { _, item -> item.category.id }) { index, item ->
                 ReorderableItem(reorderableLazyCategoriesColumnState, item.category.id) {
-                    val interactionSource = remember { MutableInteractionSource() }
                     Card(
                         onClick = {},
                         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiary),
                         shape = RoundedCornerShape(16.dp),
                         modifier = Modifier
                             .height(60.dp)
-                            .draggableHandle(
-                                onDragStarted = {},
-                                onDragStopped = {},
-                                interactionSource = interactionSource,
-                            )
+                            .detectReorderAfterLongPress(reorderableLazyCategoriesColumnState)
                             .semantics {
                                 customActions = listOf(
                                     CustomAccessibilityAction(
@@ -390,8 +385,7 @@ private fun ChildListContent(
                                         }
                                     ),
                                 )
-                            },
-                        interactionSource = interactionSource,
+                            }
                     ) {
                         Row(
                             Modifier.fillMaxSize(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=8
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- enable long press reordering for category groups and categories
- bump version to 0.8.1
- document changes in changelog

## Testing
- `./gradlew test` *(fails: No route to host)*