### PR TITLE
Add period toggle for charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2025-05-22
+### Added
+- Toggle on Insights charts for selecting time period (daily, weekly, monthly, 3M, 6M, yearly).
+
 
 ## [0.8.0] - 2025-05-21
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.presentation.components.FilterTab
+import dev.pandesal.sbp.presentation.insights.TimePeriod
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
 import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
 import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
@@ -23,6 +25,7 @@ import dev.pandesal.sbp.presentation.components.SkeletonLoader
 @Composable
 fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
     val state by viewModel.uiState.collectAsState()
+    val period by viewModel.period.collectAsState()
 
     if (state is InsightsUiState.Initial) {
         SkeletonLoader()
@@ -33,9 +36,16 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
+            FilterTab(
+                selectedIndex = period.ordinal,
+                tabs = TimePeriod.values().map { it.label }
+            ) { index ->
+                viewModel.setPeriod(TimePeriod.values()[index])
+            }
+            Spacer(modifier = Modifier.height(16.dp))
             CashflowLineChart(data.cashflow)
             Spacer(modifier = Modifier.height(16.dp))
-            BudgetVsOutflowChart(data.budgetVsOutflow)
+            BudgetVsOutflowChart(data.budgetVsOutflow, period.label)
             Spacer(modifier = Modifier.height(16.dp))
             NetWorthBarChart(data.netWorthData)
         }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
@@ -11,6 +11,7 @@ import dev.pandesal.sbp.domain.usecase.TransactionUseCase
 import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
 import dev.pandesal.sbp.presentation.model.CashflowUiModel
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
+import dev.pandesal.sbp.presentation.insights.TimePeriod
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -29,8 +30,15 @@ class InsightsViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<InsightsUiState>(InsightsUiState.Initial)
     val uiState: StateFlow<InsightsUiState> = _uiState.asStateFlow()
 
+    private val _period = MutableStateFlow(TimePeriod.MONTHLY)
+    val period: StateFlow<TimePeriod> = _period.asStateFlow()
+
     init {
         observeData()
+    }
+
+    fun setPeriod(period: TimePeriod) {
+        _period.value = period
     }
 
     private fun observeData() {
@@ -39,18 +47,10 @@ class InsightsViewModel @Inject constructor(
             combine(
                 transactionUseCase.getAllTransactions(),
                 categoryUseCase.getMonthlyBudgetsByYearMonth(YearMonth.now()),
-                accountUseCase.getAccounts()
-            ) { transactions, budgets, accounts ->
-                val cashflow = transactions
-                    .groupBy { YearMonth.from(it.createdAt) }
-                    .toSortedMap()
-                    .map { (month, txs) ->
-                        val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
-                            .sumOf { it.amount.toDouble() }
-                        val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
-                            .sumOf { it.amount.toDouble() }
-                        CashflowUiModel(month.month.name.take(3), inflow, outflow)
-                    }
+                accountUseCase.getAccounts(),
+                _period
+            ) { transactions, budgets, accounts, period ->
+                val cashflow = groupTransactionsByPeriod(transactions, period)
 
                 val totalBudget = budgets.sumOf { it.allocated.toDouble() }
                 val totalSpent = budgets.sumOf { it.spent.toDouble() }
@@ -70,6 +70,74 @@ class InsightsViewModel @Inject constructor(
             }.collect { state ->
                 _uiState.value = state
             }
+        }
+    }
+
+    private fun groupTransactionsByPeriod(
+        transactions: List<dev.pandesal.sbp.domain.model.Transaction>,
+        period: TimePeriod
+    ): List<CashflowUiModel> {
+        return when (period) {
+            TimePeriod.DAILY -> transactions
+                .groupBy { it.createdAt }
+                .toSortedMap()
+                .map { (date, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel(date.dayOfMonth.toString(), inflow, outflow)
+                }
+            TimePeriod.WEEKLY -> transactions
+                .groupBy { Pair(it.createdAt.year, it.createdAt.get(java.time.temporal.WeekFields.ISO.weekOfWeekBasedYear())) }
+                .toSortedMap(compareBy({ it.first }, { it.second }))
+                .map { (pair, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel("W${pair.second}", inflow, outflow)
+                }
+            TimePeriod.MONTHLY -> transactions
+                .groupBy { YearMonth.from(it.createdAt) }
+                .toSortedMap()
+                .map { (month, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel(month.month.name.take(3), inflow, outflow)
+                }
+            TimePeriod.THREE_MONTH -> transactions
+                .groupBy { Pair(it.createdAt.year, (it.createdAt.monthValue - 1) / 3) }
+                .toSortedMap(compareBy({ it.first }, { it.second }))
+                .map { (pair, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel("Q${pair.second + 1}", inflow, outflow)
+                }
+            TimePeriod.SIX_MONTH -> transactions
+                .groupBy { Pair(it.createdAt.year, (it.createdAt.monthValue - 1) / 6) }
+                .toSortedMap(compareBy({ it.first }, { it.second }))
+                .map { (pair, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel("H${pair.second + 1}", inflow, outflow)
+                }
+            TimePeriod.YEARLY -> transactions
+                .groupBy { it.createdAt.year }
+                .toSortedMap()
+                .map { (year, txs) ->
+                    val inflow = txs.filter { it.transactionType == TransactionType.INFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    val outflow = txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                        .sumOf { it.amount.toDouble() }
+                    CashflowUiModel(year.toString(), inflow, outflow)
+                }
         }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/TimePeriod.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/TimePeriod.kt
@@ -1,0 +1,10 @@
+package dev.pandesal.sbp.presentation.insights
+
+enum class TimePeriod(val label: String) {
+    DAILY("Day"),
+    WEEKLY("Week"),
+    MONTHLY("Month"),
+    THREE_MONTH("3M"),
+    SIX_MONTH("6M"),
+    YEARLY("Year")
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
@@ -38,6 +38,7 @@ import kotlin.math.max
 @Composable
 fun BudgetVsOutflowChart(
     entries: List<BudgetOutflowUiModel>,
+    subtitle: String = "This Month",
     modifier: Modifier = Modifier,
     barWidth: Dp = 16.dp
 ) {
@@ -70,7 +71,7 @@ fun BudgetVsOutflowChart(
 
             Text("Budget vs Outflow", style = MaterialTheme.typography.titleMedium)
             Spacer(modifier = Modifier.height(8.dp))
-            Text("This Month", style = MaterialTheme.typography.bodySmall)
+            Text(subtitle, style = MaterialTheme.typography.bodySmall)
             Spacer(modifier = Modifier.weight(1f))
             Box(
                 modifier = Modifier

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0


### PR DESCRIPTION
## Summary
- implement period selection enum
- show period filter on the insights screen
- group cashflow data by the selected period
- expose selected period state from the view model
- allow custom subtitle for budget vs outflow chart
- bump version to 0.9.0

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application'] was not found)*