### PR TITLE
Add calendar view to insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.9.0] - 2025-05-21
+### Added
+- Calendar view showing bills and transactions in Insights screen.
+
 ## [0.8.0] - 2025-05-21
 ### Added
 - Graph bars now have rounded edges and display a popup with budget or net worth details when tapped.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
 import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
 import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
+import dev.pandesal.sbp.presentation.insights.components.CalendarView
 import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
 import dev.pandesal.sbp.presentation.model.CashflowUiModel
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
@@ -33,6 +34,8 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
+            CalendarView(data.calendarEvents)
+            Spacer(modifier = Modifier.height(16.dp))
             CashflowLineChart(data.cashflow)
             Spacer(modifier = Modifier.height(16.dp))
             BudgetVsOutflowChart(data.budgetVsOutflow)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsUiState.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp.presentation.insights
 
 import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
 import dev.pandesal.sbp.presentation.model.CashflowUiModel
+import dev.pandesal.sbp.presentation.model.CalendarEvent
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 
 sealed interface InsightsUiState {
@@ -10,7 +11,8 @@ sealed interface InsightsUiState {
     data class Success(
         val cashflow: List<CashflowUiModel>,
         val budgetVsOutflow: List<BudgetOutflowUiModel>,
-        val netWorthData: List<NetWorthUiModel>
+        val netWorthData: List<NetWorthUiModel>,
+        val calendarEvents: List<CalendarEvent>
     ) : InsightsUiState
     data class Error(val errorMessage: String) : InsightsUiState
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
@@ -10,6 +10,8 @@ import dev.pandesal.sbp.domain.usecase.CategoryUseCase
 import dev.pandesal.sbp.domain.usecase.TransactionUseCase
 import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
 import dev.pandesal.sbp.presentation.model.CashflowUiModel
+import dev.pandesal.sbp.presentation.model.CalendarEvent
+import dev.pandesal.sbp.presentation.model.CalendarEventType
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +68,21 @@ class InsightsViewModel @Inject constructor(
                     .sumOf { it.balance.toDouble() }
                 val netWorth = listOf(NetWorthUiModel("Now", assets, liabilities))
 
-                InsightsUiState.Success(cashflow, budgetVsOutflow, netWorth)
+                val calendarEvents = transactions.mapNotNull { tx ->
+                    val type = when (tx.transactionType) {
+                        TransactionType.INFLOW -> CalendarEventType.INFLOW
+                        TransactionType.OUTFLOW -> CalendarEventType.OUTFLOW
+                        else -> null
+                    }
+                    type?.let { CalendarEvent(tx.createdAt, it) }
+                }
+
+                InsightsUiState.Success(
+                    cashflow,
+                    budgetVsOutflow,
+                    netWorth,
+                    calendarEvents
+                )
             }.collect { state ->
                 _uiState.value = state
             }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -1,0 +1,87 @@
+package dev.pandesal.sbp.presentation.insights.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.presentation.model.CalendarEvent
+import dev.pandesal.sbp.presentation.model.CalendarEventType
+import java.time.DayOfWeek
+import java.time.LocalDate
+
+@Composable
+fun CalendarView(
+    events: List<CalendarEvent>,
+    modifier: Modifier = Modifier
+) {
+    val today = LocalDate.now()
+    val monthStart = today.withDayOfMonth(1)
+    val daysInMonth = today.lengthOfMonth()
+    val firstDayOffset = (monthStart.dayOfWeek.value % 7)
+    val grouped = events.groupBy { it.date }
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = CardDefaults.shape,
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceAround
+            ) {
+                DayOfWeek.values().forEach { dow ->
+                    Text(dow.name.take(3))
+                }
+            }
+            for (week in 0..5) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceAround
+                ) {
+                    for (dow in 0..6) {
+                        val day = week * 7 + dow - firstDayOffset + 1
+                        if (day in 1..daysInMonth) {
+                            val date = monthStart.plusDays((day - 1).toLong())
+                            val dayEvents = grouped[date].orEmpty()
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(day.toString(), style = MaterialTheme.typography.bodySmall)
+                                Row {
+                                    dayEvents.forEach { event ->
+                                        Box(
+                                            modifier = Modifier
+                                                .padding(1.dp)
+                                                .background(colorFor(event.type), CircleShape)
+                                                .padding(3.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        } else {
+                            Box(Modifier.padding(8.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun colorFor(type: CalendarEventType): Color = when (type) {
+    CalendarEventType.INFLOW -> Color(0xFF2E7D32)
+    CalendarEventType.OUTFLOW -> Color(0xFFC62828)
+    CalendarEventType.BILL -> Color.Gray
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/CalendarEvent.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/CalendarEvent.kt
@@ -1,0 +1,14 @@
+package dev.pandesal.sbp.presentation.model
+
+import java.time.LocalDate
+
+enum class CalendarEventType {
+    INFLOW,
+    OUTFLOW,
+    BILL
+}
+
+data class CalendarEvent(
+    val date: LocalDate,
+    val type: CalendarEventType
+)

--- a/app/src/test/java/dev/pandesal/sbp/InsightsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/InsightsViewModelTest.kt
@@ -48,6 +48,7 @@ class InsightsViewModelTest {
         )
         val vm = InsightsViewModel(transactionUseCase, categoryUseCase, accountUseCase)
         advanceUntilIdle()
-        assertTrue(vm.uiState.value is InsightsUiState.Success)
+        val state = vm.uiState.value as InsightsUiState.Success
+        assertTrue(state.calendarEvents.isNotEmpty())
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=8
+versionMinor=9
 versionPatch=0


### PR DESCRIPTION
## Summary
- show a calendar with inflow, outflow and bills in Insights
- generate calendar events from transactions
- bump version to 0.9.0

## Testing
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.11.0-alpha09', apply: false] was not found)*