### PR TITLE
Add goal jar account and budget progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.0] - 2025-05-22
+### Added
+- Progress bar for category budgets.
+- Creating a goal now also creates a Goal Jar account.
+
 ## [0.17.0] - 2025-05-21
 ### Added
 - Zero-based budgeting summary with calculation of unassigned funds on the home screen.
+
 
 ## [0.16.0] - 2025-05-22
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -21,6 +21,7 @@ import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTra
 import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
+import dev.pandesal.sbp.presentation.goals.NewGoalScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -45,6 +46,8 @@ sealed class NavigationDestination() {
     data object Accounts : NavigationDestination()
     @Serializable
     data object NewAccount : NavigationDestination()
+    @Serializable
+    data object NewGoal : NavigationDestination()
     @Serializable
     data object NewRecurringTransaction : NavigationDestination()
     @Serializable
@@ -79,6 +82,12 @@ fun AppNavigation(navController: NavHostController) {
             ) {
                 NewAccountScreen()
             }
+            dialog<NavigationDestination.NewGoal>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                NewGoalScreen()
+            }
+
 
             composable<NavigationDestination.Transactions> {
                 TransactionsScreen()

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -437,7 +438,17 @@ private fun ChildListContent(
                                 if (item.budget != null) {
                                     item.budget.let {
                                         val symbol = it.currency.currencySymbol()
-                                        Text("$symbol${it.spent.format()} / $symbol${it.allocated.format()}")
+                                        Column(horizontalAlignment = Alignment.End) {
+                                            Text("$symbol${it.spent.format()} / $symbol${it.allocated.format()}")
+                                            LinearProgressIndicator(
+                                                progress = {
+                                                    if (it.allocated > BigDecimal.ZERO)
+                                                        (it.spent / it.allocated).toFloat().coerceIn(0f, 1f)
+                                                    else 0f
+                                                },
+                                                modifier = Modifier.fillMaxWidth(0.5f)
+                                            )
+                                        }
                                     }
                                 } else {
                                     TextButton(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/goals/GoalsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/goals/GoalsViewModel.kt
@@ -5,6 +5,9 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.pandesal.sbp.domain.model.Goal
 import dev.pandesal.sbp.domain.usecase.GoalUseCase
+import dev.pandesal.sbp.domain.usecase.AccountUseCase
+import dev.pandesal.sbp.domain.model.Account
+import dev.pandesal.sbp.domain.model.AccountType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,7 +18,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class GoalsViewModel @Inject constructor(
-    private val useCase: GoalUseCase
+    private val useCase: GoalUseCase,
+    private val accountUseCase: AccountUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<GoalsUiState>(GoalsUiState.Loading)
@@ -29,9 +33,16 @@ class GoalsViewModel @Inject constructor(
         }
     }
 
-    fun addGoal(name: String, target: BigDecimal, current: BigDecimal = BigDecimal.ZERO, dueDate: LocalDate? = null) {
+    fun addGoal(
+        name: String,
+        target: BigDecimal,
+        current: BigDecimal = BigDecimal.ZERO,
+        dueDate: LocalDate? = null
+    ) {
         viewModelScope.launch {
             useCase.insertGoal(Goal(name = name, target = target, current = current, dueDate = dueDate))
+            val account = Account(name = "$name Goal Jar", type = AccountType.CASH_WALLET)
+            accountUseCase.insertAccount(account)
         }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/goals/NewGoalScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/goals/NewGoalScreen.kt
@@ -1,0 +1,204 @@
+package dev.pandesal.sbp.presentation.goals
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewGoalScreen(viewModel: GoalsViewModel = hiltViewModel()) {
+    val nav = LocalNavigationManager.current
+    NewGoalScreen(
+        onSubmit = { name, amount, date ->
+            viewModel.addGoal(name, amount, dueDate = date)
+            nav.navigateUp()
+        },
+        onCancel = { nav.navigateUp() },
+        onDismissRequest = { nav.navigateUp() }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun NewGoalScreen(
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    onSubmit: (String, BigDecimal, LocalDate?) -> Unit,
+    onCancel: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var amount by remember { mutableStateOf(BigDecimal.ZERO) }
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.End
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            IconButton(
+                modifier = Modifier
+                    .height(24.dp)
+                    .padding(4.dp),
+                onClick = {
+                    onCancel()
+                    onDismissRequest()
+                }
+            ) {
+                Icon(Icons.Filled.Close, contentDescription = null)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = amount.toString(),
+                    onValueChange = { amount = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
+                    label = { Text("Target Amount") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp)
+                )
+                if (selectedTab == 1) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(selectedDate?.toString() ?: "Select Due Date")
+                        IconButton(onClick = { showDatePicker = true }) {
+                            Icon(Icons.Filled.Check, contentDescription = null)
+                        }
+                    }
+                }
+
+                Row(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
+                ) {
+                    val options = listOf("Budget", "Goal")
+                    options.forEachIndexed { index, label ->
+                        ToggleButton(
+                            checked = selectedTab == index,
+                            onCheckedChange = { selectedTab = index },
+                            modifier = Modifier.weight(1f),
+                            shapes = when (index) {
+                                0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                                options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                            }
+                        ) {
+                            Text(
+                                label,
+                                color = if (selectedTab == index) Color.White else Color.Black
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HorizontalFloatingToolbar(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            expanded = true,
+            floatingActionButton = {
+                FloatingToolbarDefaults.VibrantFloatingActionButton(
+                    onClick = {
+                        onSubmit(name, amount, selectedDate.takeIf { selectedTab == 1 })
+                        onDismissRequest()
+                    }
+                ) {
+                    Icon(Icons.Default.Check, contentDescription = null)
+                }
+            },
+            content = {}
+        )
+
+        if (showDatePicker) {
+            DatePickerDialog(
+                onDismissRequest = { showDatePicker = false },
+                confirmButton = {
+                    IconButton(onClick = {
+                        datePickerState.selectedDateMillis?.let { millis ->
+                            selectedDate = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+                        }
+                        showDatePicker = false
+                    }) { Icon(Icons.Default.Check, contentDescription = null) }
+                },
+                dismissButton = {
+                    IconButton(onClick = { showDatePicker = false }) { Icon(Icons.Default.Close, contentDescription = null) }
+                }
+            ) {
+                DatePicker(state = datePickerState)
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/GoalsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/GoalsViewModelTest.kt
@@ -2,7 +2,9 @@ package dev.pandesal.sbp
 
 import dev.pandesal.sbp.domain.model.Goal
 import dev.pandesal.sbp.domain.usecase.GoalUseCase
+import dev.pandesal.sbp.domain.usecase.AccountUseCase
 import dev.pandesal.sbp.fakes.FakeGoalRepository
+import dev.pandesal.sbp.fakes.FakeAccountRepository
 import dev.pandesal.sbp.presentation.goals.GoalsUiState
 import dev.pandesal.sbp.presentation.goals.GoalsViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,14 +22,16 @@ class GoalsViewModelTest {
     val dispatcherRule = MainDispatcherRule()
 
     private val repository = FakeGoalRepository()
+    private val accountRepository = FakeAccountRepository()
     private val useCase = GoalUseCase(repository)
+    private val accountUseCase = AccountUseCase(accountRepository)
 
     @Test
     fun uiStateEmitsGoals() = runTest {
         val goal = Goal(name = "Travel", target = BigDecimal.TEN)
         repository.goalsFlow.value = listOf(goal)
 
-        val vm = GoalsViewModel(useCase)
+        val vm = GoalsViewModel(useCase, accountUseCase)
         advanceUntilIdle()
 
         val state = vm.uiState.value as GoalsUiState.Success
@@ -36,10 +40,11 @@ class GoalsViewModelTest {
 
     @Test
     fun addGoalInsertsGoal() = runTest {
-        val vm = GoalsViewModel(useCase)
+        val vm = GoalsViewModel(useCase, accountUseCase)
         vm.addGoal("Save", BigDecimal.ONE)
         advanceUntilIdle()
         assertEquals(1, repository.insertedGoals.size)
         assertEquals("Save", repository.insertedGoals[0].name)
+        assertEquals(1, accountRepository.insertedAccounts.size)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=17
+versionMinor=18
 versionPatch=0


### PR DESCRIPTION
## Summary
- add progress bar for category budgets
- create a Goal Jar account whenever a goal is added
- support creating goals via new dialog screen
- expose new Goal dialog in navigation
- bump version to 0.18.0

## Testing
- `./gradlew test` *(fails: Downloading https://services.gradle.org/distributions/gradle-8.13-bin.zip)*