### PR TITLE
Implement scrollable insights with configurable periods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] - 2025-05-24
+### Added
+- Scrollable Insights screen with individual date range dropdowns for each chart.
+- Fixed calendar alignment issues.
+
 ## [0.19.9] - 2025-05-22
 ### Changed
 - Replaced filter tabs with a docked tab row in the Notifications screen.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -1,6 +1,7 @@
 package dev.pandesal.sbp.presentation.accounts
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,6 +21,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -42,7 +44,7 @@ import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.SquigglyDivider
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AccountsScreen(
     viewModel: AccountsViewModel = hiltViewModel()
@@ -51,22 +53,31 @@ fun AccountsScreen(
     var showNew by remember { mutableStateOf(false) }
     val navigationManager = LocalNavigationManager.current
 
-    when (val state = uiState) {
-        is AccountsUiState.Loading -> {
-            Text("Loading...", modifier = Modifier.padding(16.dp))
-        }
-        is AccountsUiState.Success -> {
-            AccountsContent(
-                accounts = state.accounts,
-                onAddWallet = {
-                    navigationManager.navigate(NavigationDestination.NewAccount)
-                },
-            )
-        }
-        is AccountsUiState.Error -> {
-            Text(state.message, color = MaterialTheme.colorScheme.error)
+    Column {
+        Text(
+            modifier = Modifier.padding(16.dp),
+            text = "Accounts",
+            style = MaterialTheme.typography.titleLargeEmphasized
+        )
+
+        when (val state = uiState) {
+            is AccountsUiState.Loading -> {
+                Text("Loading...", modifier = Modifier.padding(16.dp))
+            }
+            is AccountsUiState.Success -> {
+                AccountsContent(
+                    accounts = state.accounts,
+                    onAddWallet = {
+                        navigationManager.navigate(NavigationDestination.NewAccount)
+                    },
+                )
+            }
+            is AccountsUiState.Error -> {
+                Text(state.message, color = MaterialTheme.colorScheme.error)
+            }
         }
     }
+
 }
 
 @Composable
@@ -95,7 +106,7 @@ private fun AccountsContent(
                     text = "Total: $symbol${totalValue.format()}",
                     style = MaterialTheme.typography.titleMedium,
                 )
-                Button(onClick = onAddWallet) { Text("Add Wallet") }
+                Button(onClick = onAddWallet) { Text("Add Wallet", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimary) }
             }
         }
         item {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -82,7 +83,7 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import java.math.BigDecimal
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun CategoriesListContent(
     parentList: List<CategoryGroup>,
@@ -129,6 +130,7 @@ private fun CategoriesListContent(
     var editCategory by remember { mutableStateOf<Category?>(null) }
 
     Column(modifier = Modifier.fillMaxSize()) {
+
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             state = lazyGroupsState,
@@ -464,7 +466,7 @@ private fun ChildListContent(
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 fun CategoriesScreen(
     viewModel: CategoriesViewModel = hiltViewModel()
 ) {
@@ -615,6 +617,13 @@ fun CategoriesScreen(
                     .fillMaxSize()
                     .padding(16.dp)
             ) {
+                Text(
+                    text = "Categories & Budgets",
+                    style = MaterialTheme.typography.titleLargeEmphasized
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
                 if (percentages.isNotEmpty()) {
                     CategoryBudgetPieChart(percentages)
                 } else {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/components/TimePeriodDropdown.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/components/TimePeriodDropdown.kt
@@ -1,0 +1,44 @@
+package dev.pandesal.sbp.presentation.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import dev.pandesal.sbp.presentation.insights.TimePeriod
+
+@Composable
+fun TimePeriodDropdown(
+    period: TimePeriod,
+    onPeriodChange: (TimePeriod) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier) {
+        TextButton(onClick = { expanded = true }) {
+            Text(period.label)
+            Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            TimePeriod.values().forEach { p ->
+                DropdownMenuItem(
+                    text = { Text(p.label) },
+                    onClick = {
+                        expanded = false
+                        onPeriodChange(p)
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.components.FilterTab
+import dev.pandesal.sbp.presentation.components.TimePeriodDropdown
 import dev.pandesal.sbp.presentation.insights.TimePeriod
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
 import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
@@ -27,6 +30,10 @@ import dev.pandesal.sbp.presentation.components.SkeletonLoader
 fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
     val state by viewModel.uiState.collectAsState()
     val period by viewModel.period.collectAsState()
+
+    var cashflowPeriod by remember { mutableStateOf(period) }
+    var budgetPeriod by remember { mutableStateOf(period) }
+    var netWorthPeriod by remember { mutableStateOf(period) }
 
     if (state is InsightsUiState.Initial) {
         SkeletonLoader()
@@ -48,10 +55,15 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
             CalendarView(data.calendarEvents)
 
             Spacer(modifier = Modifier.height(16.dp))
-            CashflowLineChart(data.cashflow)
+            TimePeriodDropdown(period = cashflowPeriod, onPeriodChange = { cashflowPeriod = it })
+            CashflowLineChart(data.cashflowByPeriod[cashflowPeriod] ?: emptyList())
+
             Spacer(modifier = Modifier.height(16.dp))
-            BudgetVsOutflowChart(data.budgetVsOutflow, period.label)
+            TimePeriodDropdown(period = budgetPeriod, onPeriodChange = { budgetPeriod = it })
+            BudgetVsOutflowChart(data.budgetVsOutflow, budgetPeriod.label)
+
             Spacer(modifier = Modifier.height(16.dp))
+            TimePeriodDropdown(period = netWorthPeriod, onPeriodChange = { netWorthPeriod = it })
             NetWorthBarChart(data.netWorthData)
         }
     }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -1,31 +1,33 @@
 package dev.pandesal.sbp.presentation.insights
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import dev.pandesal.sbp.presentation.components.FilterTab
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.components.TimePeriodDropdown
-import dev.pandesal.sbp.presentation.insights.TimePeriod
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
 import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
-import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
 import dev.pandesal.sbp.presentation.insights.components.CalendarView
-import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
-import dev.pandesal.sbp.presentation.model.CashflowUiModel
-import dev.pandesal.sbp.presentation.model.NetWorthUiModel
-import dev.pandesal.sbp.presentation.components.SkeletonLoader
+import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
     val state by viewModel.uiState.collectAsState()
@@ -44,27 +46,45 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp)
         ) {
+            Text(
+                text = "Insights",
+                style = MaterialTheme.typography.titleLargeEmphasized
+            )
 
-            FilterTab(
-                selectedIndex = period.ordinal,
-                tabs = TimePeriod.values().map { it.label }
-            ) { index ->
-                viewModel.setPeriod(TimePeriod.values()[index])
-            }
+            Spacer(modifier = Modifier.height(16.dp))
 
             CalendarView(data.calendarEvents)
 
             Spacer(modifier = Modifier.height(16.dp))
-            TimePeriodDropdown(period = cashflowPeriod, onPeriodChange = { cashflowPeriod = it })
-            CashflowLineChart(data.cashflowByPeriod[cashflowPeriod] ?: emptyList())
+
+            Box {
+                CashflowLineChart(data.cashflowByPeriod[cashflowPeriod] ?: emptyList())
+                TimePeriodDropdown(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    period = cashflowPeriod, onPeriodChange = { cashflowPeriod = it }
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
-            TimePeriodDropdown(period = budgetPeriod, onPeriodChange = { budgetPeriod = it })
-            BudgetVsOutflowChart(data.budgetVsOutflow, budgetPeriod.label)
+
+            Box {
+                BudgetVsOutflowChart(data.budgetVsOutflow, budgetPeriod.label)
+                TimePeriodDropdown(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    period = budgetPeriod, onPeriodChange = { budgetPeriod = it }
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
-            TimePeriodDropdown(period = netWorthPeriod, onPeriodChange = { netWorthPeriod = it })
-            NetWorthBarChart(data.netWorthData)
+
+            Box {
+                NetWorthBarChart(data.netWorthData)
+                TimePeriodDropdown(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    period = netWorthPeriod, onPeriodChange = { netWorthPeriod = it }
+                )
+            }
+            Spacer(modifier = Modifier.height(140.dp))
         }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsUiState.kt
@@ -9,7 +9,7 @@ sealed interface InsightsUiState {
     data object Initial : InsightsUiState
     data object Loading : InsightsUiState
     data class Success(
-        val cashflow: List<CashflowUiModel>,
+        val cashflowByPeriod: Map<TimePeriod, List<CashflowUiModel>>,
         val budgetVsOutflow: List<BudgetOutflowUiModel>,
         val netWorthData: List<NetWorthUiModel>,
         val calendarEvents: List<CalendarEvent>

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
@@ -49,10 +49,11 @@ class InsightsViewModel @Inject constructor(
             combine(
                 transactionUseCase.getAllTransactions(),
                 categoryUseCase.getMonthlyBudgetsByYearMonth(YearMonth.now()),
-                accountUseCase.getAccounts(),
-                _period
-            ) { transactions, budgets, accounts, period ->
-                val cashflow = groupTransactionsByPeriod(transactions, period)
+                accountUseCase.getAccounts()
+            ) { transactions, budgets, accounts ->
+                val cashflowByPeriod = TimePeriod.values().associateWith { p ->
+                    groupTransactionsByPeriod(transactions, p)
+                }
 
                 val totalBudget = budgets.sumOf { it.allocated.toDouble() }
                 val totalSpent = budgets.sumOf { it.spent.toDouble() }
@@ -78,7 +79,7 @@ class InsightsViewModel @Inject constructor(
                 }
 
                 InsightsUiState.Success(
-                    cashflow,
+                    cashflowByPeriod,
                     budgetVsOutflow,
                     netWorth,
                     calendarEvents

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -30,7 +30,7 @@ fun CalendarView(
     val today = LocalDate.now()
     val monthStart = today.withDayOfMonth(1)
     val daysInMonth = today.lengthOfMonth()
-    val firstDayOffset = (monthStart.dayOfWeek.value % 7)
+    val firstDayOffset = monthStart.dayOfWeek.ordinal
     val grouped = events.groupBy { it.date }
 
     Card(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
@@ -16,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.model.CalendarEvent
 import dev.pandesal.sbp.presentation.model.CalendarEventType
@@ -39,14 +42,19 @@ fun CalendarView(
         elevation = CardDefaults.cardElevation(4.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
+            Text("Transaction Calendar", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceAround
             ) {
-                DayOfWeek.values().forEach { dow ->
-                    Text(dow.name.take(3))
+                DayOfWeek.entries.forEach { dow ->
+                    Text(dow.name.take(3), modifier = Modifier.weight(1f), textAlign = TextAlign.Center)
                 }
             }
+            Spacer(modifier = Modifier.height(8.dp))
+
             for (week in 0..5) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -57,8 +65,10 @@ fun CalendarView(
                         if (day in 1..daysInMonth) {
                             val date = monthStart.plusDays((day - 1).toLong())
                             val dayEvents = grouped[date].orEmpty()
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(day.toString(), style = MaterialTheme.typography.bodySmall)
+                            Column(
+                                modifier = Modifier.weight(1f).height(50.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(day.toString(), style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.End)
                                 Row {
                                     dayEvents.forEach { event ->
                                         Box(
@@ -71,7 +81,7 @@ fun CalendarView(
                                 }
                             }
                         } else {
-                            Box(Modifier.padding(8.dp))
+                            Box(Modifier.weight(1f))
                         }
                     }
                 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 
 @Composable
 fun SettingsScreen(
@@ -51,7 +52,7 @@ private data class SettingItem(
 
 private enum class SettingType { SWITCH, TEXT }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun SettingsContent(
     settings: dev.pandesal.sbp.domain.model.Settings,
@@ -81,7 +82,7 @@ private fun SettingsContent(
         item {
             Text(
                 text = "Settings",
-                style = MaterialTheme.typography.headlineMedium
+                style = MaterialTheme.typography.titleLargeEmphasized
             )
         }
         items(items) { item ->

--- a/app/src/main/java/dev/pandesal/sbp/presentation/theme/Type.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/theme/Type.kt
@@ -1,5 +1,6 @@
 package dev.pandesal.sbp.presentation.theme
 
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import dev.pandesal.sbp.R
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
@@ -25,6 +26,7 @@ object AppFont {
 
 
 private val defaultTypography = Typography()
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 val Typography = Typography(
     displayLarge = defaultTypography.displayLarge
         .copy(fontFamily = AppFont.ManRope),
@@ -36,6 +38,7 @@ val Typography = Typography(
     headlineSmall = defaultTypography.headlineSmall.copy(fontFamily = AppFont.ManRope),
 
     titleLarge = defaultTypography.titleLarge.copy(fontFamily = AppFont.ManRope),
+    titleLargeEmphasized = defaultTypography.titleLargeEmphasized.copy(fontFamily = AppFont.ManRope, fontWeight = FontWeight.Bold),
     titleMedium = defaultTypography.titleMedium.copy(fontFamily = AppFont.ManRope),
     titleSmall = defaultTypography.titleSmall.copy(fontFamily = AppFont.ManRope),
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=19
+versionMinor=20
 versionPatch=0


### PR DESCRIPTION
## Summary
- allow choosing a time period per chart using `TimePeriodDropdown`
- fix calendar alignment by adjusting day offset
- compute cashflow for all periods
- bump version to 0.20.0

## Testing
- `gradle test -x lint` *(fails: Plugin not found)*