### PR TITLE
Add default transfer categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2025-05-19
+### Added
+- Default "Transfers" category group with Adjustment, Goal Contribution and Loan Payment categories.
+- New transactions default to the Adjustment category when Transfer is selected.
+
 ## [0.21.0] - 2025-05-19
 ### Added
 - Progress bar for category budgets.

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -76,6 +76,18 @@ abstract class SbpDatabase : RoomDatabase(), DatabaseDaos {
                                 db.execSQL(
                                     "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (6, 'Gift', '', '', 1, 'INFLOW', 0, 0, 0, 1)"
                                 )
+                                db.execSQL(
+                                    "INSERT INTO category_groups (id, name, description, icon, weight, isFavorite, isArchived, isSystemSet) VALUES (2, 'Transfers', '', '', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (28, 'Adjustment', '', '', 2, 'TRANSFER', 0, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (29, 'Goal Contribution', '', '', 2, 'TRANSFER', 1, 0, 0, 1)"
+                                )
+                                db.execSQL(
+                                    "INSERT INTO categories (id, name, icon, description, categoryGroupId, categoryType, weight, isFavorite, isArchived, isSystemSet) VALUES (30, 'Loan Payment', '', '', 2, 'TRANSFER', 2, 0, 0, 1)"
+                                )
                             }
                         })
                         .fallbackToDestructiveMigration()

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -116,6 +116,17 @@ class NewTransactionsViewModel @Inject constructor(
                     newTransaction = newTransaction.copy(category = salary)
                 }
             }
+        } else if (_transaction.value.transactionType != newTransaction.transactionType &&
+            newTransaction.transactionType == TransactionType.TRANSFER
+        ) {
+            val current = _uiState.value
+            if (current is NewTransactionUiState.Success) {
+                val adjustment = current.groupedCategories.values.flatten()
+                    .firstOrNull { it.name.equals("Adjustment", ignoreCase = true) }
+                if (adjustment != null) {
+                    newTransaction = newTransaction.copy(category = adjustment)
+                }
+            }
         }
 
         if (_transaction.value.category?.id != newTransaction.category?.id && newTransaction.category != null) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=21
+versionMinor=22
 versionPatch=0


### PR DESCRIPTION
## Summary
- seed transfer category group with Adjustment, Goal Contribution and Loan Payment categories
- set default Adjustment category when creating a transfer
- update version to 0.22.0
- document changes in CHANGELOG

## Testing
- `./gradlew test --quiet` *(fails: No route to host)*