### PR TITLE
Add upcoming recurring transaction notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2025-05-19
+### Added
+- Upcoming due reminders for recurring transactions in Notification Center.
+
 ## [0.21.0] - 2025-05-19
 ### Added
 - Progress bar for category budgets.

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/RecurringTransactionRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/RecurringTransactionRepository.kt
@@ -1,0 +1,24 @@
+package dev.pandesal.sbp.data.repository
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RecurringTransactionRepository @Inject constructor() : RecurringTransactionRepositoryInterface {
+    private val recurringTransactions = MutableStateFlow<List<RecurringTransaction>>(emptyList())
+
+    override fun getRecurringTransactions(): StateFlow<List<RecurringTransaction>> = recurringTransactions.asStateFlow()
+
+    override suspend fun addRecurringTransaction(transaction: RecurringTransaction) {
+        recurringTransactions.value = recurringTransactions.value + transaction
+    }
+
+    override suspend fun removeRecurringTransaction(transaction: RecurringTransaction) {
+        recurringTransactions.value = recurringTransactions.value - transaction
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -16,11 +16,13 @@ import dev.pandesal.sbp.data.repository.TransactionRepository
 import dev.pandesal.sbp.data.repository.AccountRepository
 import dev.pandesal.sbp.data.repository.GoalRepository
 import dev.pandesal.sbp.data.repository.SettingsRepository
+import dev.pandesal.sbp.data.repository.RecurringTransactionRepository
 import dev.pandesal.sbp.domain.repository.CategoryRepositoryInterface
 import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
 import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
 import dev.pandesal.sbp.domain.repository.GoalRepositoryInterface
 import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
+import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -98,6 +100,12 @@ object DataModule {
         @ApplicationContext context: Context
     ): SettingsRepositoryInterface {
         return SettingsRepository(context)
+    }
+
+    @Singleton
+    @Provides
+    fun provideRecurringTransactionRepository(): RecurringTransactionRepositoryInterface {
+        return RecurringTransactionRepository()
     }
 
 

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/RecurringTransactionRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/RecurringTransactionRepositoryInterface.kt
@@ -1,0 +1,10 @@
+package dev.pandesal.sbp.domain.repository
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import kotlinx.coroutines.flow.Flow
+
+interface RecurringTransactionRepositoryInterface {
+    fun getRecurringTransactions(): Flow<List<RecurringTransaction>>
+    suspend fun addRecurringTransaction(transaction: RecurringTransaction)
+    suspend fun removeRecurringTransaction(transaction: RecurringTransaction)
+}

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
@@ -1,0 +1,47 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.Notification
+import dev.pandesal.sbp.domain.model.NotificationType
+import dev.pandesal.sbp.domain.model.RecurringInterval
+import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalDate
+import javax.inject.Inject
+
+class RecurringTransactionUseCase @Inject constructor(
+    private val repository: RecurringTransactionRepositoryInterface
+) {
+    fun getUpcomingNotifications(
+        currentDate: LocalDate = LocalDate.now(),
+        withinDays: Long = 7
+    ): Flow<List<Notification>> {
+        val endDate = currentDate.plusDays(withinDays)
+        return repository.getRecurringTransactions().map { list ->
+            list.mapNotNull { rec ->
+                val next = nextDueDate(rec, currentDate)
+                if (!next.isAfter(endDate)) {
+                    Notification(
+                        message = "${rec.transaction.name} due on $next",
+                        type = NotificationType.BILL_REMINDER
+                    )
+                } else {
+                    null
+                }
+            }
+        }
+    }
+
+    private fun nextDueDate(rec: dev.pandesal.sbp.domain.model.RecurringTransaction, fromDate: LocalDate): LocalDate {
+        var due = rec.startDate
+        while (!due.isAfter(fromDate)) {
+            due = when (rec.interval) {
+                RecurringInterval.DAILY -> due.plusDays(1)
+                RecurringInterval.WEEKLY -> due.plusWeeks(1)
+                RecurringInterval.MONTHLY -> due.plusMonths(1)
+                RecurringInterval.AFTER_CUTOFF -> due.plusMonths(1).withDayOfMonth(rec.cutoffDays)
+            }
+        }
+        return due
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
@@ -36,12 +36,14 @@ import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.notification.InAppNotificationCenter
 import dev.pandesal.sbp.domain.model.NotificationType
 import dev.pandesal.sbp.presentation.LocalNavigationManager
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.notifications.NotificationCenterViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NotificationCenterScreen() {
+fun NotificationCenterScreen(viewModel: NotificationCenterViewModel = hiltViewModel()) {
     val navController = LocalNavigationManager.current
-    val notifications by InAppNotificationCenter.notifications.collectAsState()
+    val notifications by viewModel.notifications.collectAsState()
     val tabTitles = listOf(
         "All notifications",
         "Upcoming Bills Reminder",

--- a/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterViewModel.kt
@@ -1,0 +1,26 @@
+package dev.pandesal.sbp.presentation.notifications
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.Notification
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import dev.pandesal.sbp.notification.InAppNotificationCenter
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationCenterViewModel @Inject constructor(
+    private val recurringUseCase: RecurringTransactionUseCase
+) : ViewModel() {
+
+    val notifications: StateFlow<List<Notification>> = combine(
+        InAppNotificationCenter.notifications,
+        recurringUseCase.getUpcomingNotifications()
+    ) { posted, upcoming ->
+        (posted + upcoming).distinctBy { it.message }
+    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=21
+versionMinor=22
 versionPatch=0

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=22
+versionMinor=23
 versionPatch=0


### PR DESCRIPTION
## Summary
- implement simple repository and use case for recurring transactions
- show combined notifications in NotificationCenter via a new viewmodel
- wire repository through Hilt
- bump version to 0.23.0

## Testing
- `./gradlew test` *(fails: No route to host)*