### PR TITLE
Add account transaction sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.0] - 2025-05-19
+### Added
+- View wallet transactions in a bottom sheet when selecting an account.
+- Edit or delete an account from the bottom sheet header.
+
 ## [0.21.0] - 2025-05-19
 ### Added
 - Progress bar for category budgets.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountTransactionsViewModel.kt
@@ -1,0 +1,29 @@
+package dev.pandesal.sbp.presentation.accounts
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.usecase.TransactionUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class AccountTransactionsViewModel @Inject constructor(
+    private val transactionUseCase: TransactionUseCase
+) : ViewModel() {
+
+    private val _transactions = MutableStateFlow<List<Transaction>>(emptyList())
+    val transactions: StateFlow<List<Transaction>> = _transactions.asStateFlow()
+
+    fun load(accountId: String) {
+        viewModelScope.launch {
+            transactionUseCase.getTransactionsByAccountId(accountId).collect {
+                _transactions.value = it
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -1,30 +1,43 @@
 package dev.pandesal.sbp.presentation.accounts
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.clickable
+import androidx.compose.animation.Crossfade
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloseFullscreen
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.CreditCard
 import androidx.compose.material.icons.outlined.AttachMoney
 import androidx.compose.material.icons.outlined.Wallet
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.Surface
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -33,7 +46,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Alignment
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.pandesal.sbp.domain.model.AccountType
@@ -43,23 +61,126 @@ import dev.pandesal.sbp.extensions.currencySymbol
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.SquigglyDivider
+import dev.pandesal.sbp.presentation.transactions.TransactionsContent
+
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AccountsScreen(
-    viewModel: AccountsViewModel = hiltViewModel()
+    viewModel: AccountsViewModel = hiltViewModel(),
+    txViewModel: AccountTransactionsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var showNew by remember { mutableStateOf(false) }
+    val transactions by txViewModel.transactions.collectAsState()
     val navigationManager = LocalNavigationManager.current
 
-    Column {
-        Text(
-            modifier = Modifier.padding(16.dp),
-            text = "Accounts",
-            style = MaterialTheme.typography.titleLargeEmphasized
-        )
+    var selectedAccount by remember { mutableStateOf<dev.pandesal.sbp.domain.model.Account?>(null) }
+    var showRename by remember { mutableStateOf(false) }
+    var showDelete by remember { mutableStateOf(false) }
 
+    val scaffoldState = rememberBottomSheetScaffoldState()
+    var isIconExpanded by remember { mutableStateOf(scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(scaffoldState.bottomSheetState.targetValue) {
+        isIconExpanded = scaffoldState.bottomSheetState.targetValue == SheetValue.Expanded
+    }
+
+    LaunchedEffect(selectedAccount) {
+        selectedAccount?.let {
+            txViewModel.load(it.id.toString())
+            scope.launch { scaffoldState.bottomSheetState.expand() }
+        }
+    }
+
+    if (showRename && selectedAccount != null) {
+        RenameAccountSheet(
+            currentName = selectedAccount!!.name,
+            onSubmit = { name ->
+                viewModel.updateAccountName(selectedAccount!!, name)
+                showRename = false
+            },
+            onCancel = { showRename = false },
+            onDismissRequest = { showRename = false }
+        )
+    }
+
+    if (showDelete && selectedAccount != null) {
+        AlertDialog(
+            onDismissRequest = { showDelete = false },
+            confirmButton = {
+                Button(onClick = {
+                    viewModel.deleteAccount(selectedAccount!!)
+                    showDelete = false
+                    selectedAccount = null
+                }) { Text("Delete") }
+            },
+            dismissButton = {
+                Button(onClick = { showDelete = false }) { Text("Cancel") }
+            },
+            title = { Text("Delete Account") },
+            text = { Text("Are you sure you want to delete this account?") }
+        )
+    }
+
+    BottomSheetScaffold(
+        containerColor = Color.Transparent,
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = 0.dp,
+        sheetShadowElevation = 16.dp,
+        sheetContent = {
+            TransactionsContent(
+                transactions = transactions,
+                onNewTransactionClick = { navigationManager.navigate(NavigationDestination.NewTransaction) },
+                onTransactionClick = { navigationManager.navigate(NavigationDestination.TransactionDetails(it.id)) }
+            )
+        },
+        sheetDragHandle = {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Surface(
+                    modifier = Modifier
+                        .padding(top = 16.dp)
+                        .semantics { contentDescription = "drag handle" },
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    shape = MaterialTheme.shapes.extraLarge
+                ) {
+                    Box(Modifier.size(width = 32.dp, height = 4.dp))
+                }
+
+                Row(
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Transactions", style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.weight(1f))
+                    IconButton(onClick = { showRename = true }, enabled = selectedAccount != null) {
+                        Icon(Icons.Default.Edit, contentDescription = null)
+                    }
+                    IconButton(onClick = { showDelete = true }, enabled = selectedAccount != null) {
+                        Icon(Icons.Default.Delete, contentDescription = null)
+                    }
+                    IconButton(onClick = {
+                        isIconExpanded = !isIconExpanded
+                        scope.launch {
+                            if (scaffoldState.bottomSheetState.currentValue == SheetValue.Expanded) {
+                                scaffoldState.bottomSheetState.partialExpand()
+                            } else {
+                                scaffoldState.bottomSheetState.expand()
+                            }
+                        }
+                    }) {
+                        androidx.compose.animation.Crossfade(targetState = isIconExpanded, label = "icon crossfade") { expanded ->
+                            if (expanded) {
+                                Icon(Icons.Default.CloseFullscreen, contentDescription = null)
+                            } else {
+                                Icon(Icons.Default.Fullscreen, contentDescription = null)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ) { padding ->
         when (val state = uiState) {
             is AccountsUiState.Loading -> {
                 Text("Loading...", modifier = Modifier.padding(16.dp))
@@ -67,9 +188,9 @@ fun AccountsScreen(
             is AccountsUiState.Success -> {
                 AccountsContent(
                     accounts = state.accounts,
-                    onAddWallet = {
-                        navigationManager.navigate(NavigationDestination.NewAccount)
-                    },
+                    onAddWallet = { navigationManager.navigate(NavigationDestination.NewAccount) },
+                    onAccountClick = { selectedAccount = it },
+                    modifier = Modifier.padding(padding)
                 )
             }
             is AccountsUiState.Error -> {
@@ -84,6 +205,7 @@ fun AccountsScreen(
 private fun AccountsContent(
     accounts: List<dev.pandesal.sbp.domain.model.Account>,
     onAddWallet: () -> Unit,
+    onAccountClick: (dev.pandesal.sbp.domain.model.Account) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val totalValue = accounts.sumOf { it.balance.toDouble() }
@@ -117,7 +239,11 @@ private fun AccountsContent(
             )
         }
         items(accounts, key = { it.id }) { account ->
-            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            ElevatedCard(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onAccountClick(account) }
+            ) {
                 ListItem(
                     headlineContent = { Text(account.name) },
                     supportingContent = { Text(account.type.label(), style = MaterialTheme.typography.bodySmall) },

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsViewModel.kt
@@ -80,4 +80,16 @@ class AccountsViewModel @Inject constructor(
             }
         }
     }
+
+    fun updateAccountName(account: Account, name: String) {
+        viewModelScope.launch {
+            useCase.insertAccount(account.copy(name = name))
+        }
+    }
+
+    fun deleteAccount(account: Account) {
+        viewModelScope.launch {
+            useCase.deleteAccount(account)
+        }
+    }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/RenameAccountSheet.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/RenameAccountSheet.kt
@@ -1,0 +1,63 @@
+package dev.pandesal.sbp.presentation.accounts
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RenameAccountSheet(
+    currentName: String,
+    onSubmit: (String) -> Unit,
+    onCancel: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val name = remember { mutableStateOf(currentName) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("Edit Account Name", style = MaterialTheme.typography.titleLarge)
+            OutlinedTextField(
+                value = name.value,
+                onValueChange = { name.value = it },
+                label = { Text("Account Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                androidx.compose.foundation.layout.Spacer(Modifier.size(8.dp))
+                Button(onClick = { onSubmit(name.value) }, enabled = name.value.isNotBlank()) {
+                    Text("Save")
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=21
+versionMinor=22
 versionPatch=0

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=22
+versionMinor=24
 versionPatch=0


### PR DESCRIPTION
## Summary
- show transactions for a wallet in a bottom sheet
- allow renaming or deleting the account from the sheet
- bump version to 0.24.0

## Testing
- `./gradlew test` *(fails: No route to host)*