### PR TITLE
Add dialog routes for new categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2025-05-19
+### Changed
+- Budget/Goal toggle moved from the New Category form to the Set Budget sheet.
+- Set Budget sheet redesigned with a floating toolbar.
+
+## [0.25.0] - 2025-05-19
+### Added
+- Navigation dialogs for creating new categories and category groups.
+### Changed
+- New Category and Category Group screens now use a floating toolbar with a Budget/Goal toggle.
+
 
 ## [0.24.0] - 2025-05-19
 ### Added

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -51,6 +51,10 @@ sealed class NavigationDestination() {
     @Serializable
     data object NewRecurringTransaction : NavigationDestination()
     @Serializable
+    data object NewCategoryGroup : NavigationDestination()
+    @Serializable
+    data class NewCategory(val groupId: Int, val groupName: String) : NavigationDestination()
+    @Serializable
     data class TransactionDetails(val transactionId: String) : NavigationDestination()
 
 }
@@ -86,6 +90,19 @@ fun AppNavigation(navController: NavHostController) {
                 dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
             ) {
                 NewGoalScreen()
+            }
+
+            dialog<NavigationDestination.NewCategoryGroup>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                NewCategoryGroupScreen()
+            }
+
+            dialog<NavigationDestination.NewCategory>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+            ) { backStackEntry ->
+                val args = backStackEntry.toRoute<NavigationDestination.NewCategory>()
+                NewCategoryScreen(groupId = args.groupId, groupName = args.groupName)
             }
 
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetSheet.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetSheet.kt
@@ -1,67 +1,183 @@
 package dev.pandesal.sbp.presentation.categories.budget
 
-import java.math.BigDecimal
-
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material3.ToggleButton
+import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.twotone.DateRange
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun SetBudgetSheet(
     initialAmount: BigDecimal = BigDecimal.ZERO,
-    onSubmit: (BigDecimal) -> Unit,
+    onSubmit: (amount: BigDecimal, isGoal: Boolean, dueDate: LocalDate?) -> Unit,
     onCancel: () -> Unit,
-    onDismissRequest: () -> Unit
+    onDismissRequest: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState()
 ) {
-    val amount = remember { mutableStateOf(initialAmount) }
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var amount by remember { mutableStateOf(initialAmount) }
+    var selectedTab by remember { mutableIntStateOf(0) }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val datePickerState = rememberDatePickerState()
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState,
+        sheetState = sheetState
     ) {
         Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                .fillMaxSize()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.End
         ) {
-            Text("Set Target Budget", style = MaterialTheme.typography.titleLarge)
-            OutlinedTextField(
-                value = amount.value.toString(),
-                onValueChange = { amount.value = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
-                label = { Text("Amount") },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true
-            )
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End
+            Spacer(modifier = Modifier.weight(1f))
+
+            ElevatedCard(
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+                elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
             ) {
-                TextButton(onClick = onCancel) {
-                    Text("Cancel")
+                IconButton(
+                    modifier = Modifier
+                        .height(24.dp)
+                        .padding(4.dp),
+                    onClick = {
+                        onCancel()
+                        onDismissRequest()
+                    }
+                ) {
+                    Icon(Icons.Filled.Close, contentDescription = null)
                 }
-                Spacer(modifier = Modifier.size(8.dp))
-                Button(onClick = { onSubmit(amount.value) }) {
-                    Text("Save")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ElevatedCard(
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+                elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
+                    ) {
+                        val options = listOf("Budget", "Goal")
+                        options.forEachIndexed { index, label ->
+                            ToggleButton(
+                                checked = selectedTab == index,
+                                onCheckedChange = { selectedTab = index },
+                                modifier = Modifier.weight(1f),
+                                shapes = when (index) {
+                                    0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
+                                    options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
+                                    else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
+                                }
+                            ) {
+                                Text(label, color = if (selectedTab == index) Color.White else Color.Black)
+                            }
+                        }
+                    }
+
+                    OutlinedTextField(
+                        value = amount.toString(),
+                        onValueChange = { amount = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
+                        label = { Text("Amount") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 16.dp),
+                        singleLine = true
+                    )
+
+                    if (selectedTab == 1) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 16.dp)
+                                .clickable { showDatePicker = true },
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(selectedDate?.toString() ?: "Select Due Date")
+                            Icon(Icons.TwoTone.DateRange, contentDescription = null)
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            HorizontalFloatingToolbar(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                expanded = true,
+                floatingActionButton = {
+                    FloatingToolbarDefaults.VibrantFloatingActionButton(
+                        onClick = {
+                            onSubmit(amount, selectedTab == 1, selectedDate.takeIf { selectedTab == 1 })
+                            onDismissRequest()
+                        },
+                        enabled = amount > BigDecimal.ZERO
+                    ) {
+                        Icon(Icons.Default.Check, contentDescription = null)
+                    }
+                },
+                content = {}
+            )
+
+            if (showDatePicker) {
+                DatePickerDialog(
+                    onDismissRequest = { showDatePicker = false },
+                    confirmButton = {
+                        IconButton(onClick = {
+                            datePickerState.selectedDateMillis?.let { millis ->
+                                selectedDate = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+                            }
+                            showDatePicker = false
+                        }) { Icon(Icons.Default.Check, contentDescription = null) }
+                    },
+                    dismissButton = {
+                        IconButton(onClick = { showDatePicker = false }) { Icon(Icons.Default.Close, contentDescription = null) }
+                    }
+                ) {
+                    DatePicker(state = datePickerState)
                 }
             }
         }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryGroupScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryGroupScreen.kt
@@ -2,15 +2,22 @@ package dev.pandesal.sbp.presentation.categories.new
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -21,9 +28,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import dev.pandesal.sbp.presentation.categories.CategoriesViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun NewCategoryGroupScreen(
+    viewModel: CategoriesViewModel = hiltViewModel()
+) {
+    val nav = LocalNavigationManager.current
+    NewCategoryGroupScreen(
+        onSubmit = { name ->
+            viewModel.createCategoryGroup(name)
+            nav.navigateUp()
+        },
+        onCancel = { nav.navigateUp() },
+        onDismissRequest = { nav.navigateUp() }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NewCategoryGroupScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
@@ -34,45 +61,73 @@ fun NewCategoryGroupScreen(
 ) {
     var name by remember { mutableStateOf(initialName) }
 
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.End
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+        Spacer(modifier = Modifier.weight(1f))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
         ) {
-            Text("Group Name")
-            ElevatedCard(
+            IconButton(
                 modifier = Modifier
-                    .padding(top = 4.dp)
-                    .fillMaxWidth(),
-                elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
-            ) {
-                BasicTextField(
-                    value = name,
-                    onValueChange = { name = it },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                )
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                Button(onClick = {
-                    onSubmit(name)
-                    onDismissRequest()
-                }, enabled = name.isNotBlank()) {
-                    Text("Save")
-                }
-                OutlinedButton(onClick = {
+                    .height(24.dp)
+                    .padding(4.dp),
+                onClick = {
                     onCancel()
                     onDismissRequest()
-                }) {
-                    Text("Cancel")
+                }
+            ) {
+                Icon(Icons.Filled.Close, contentDescription = null)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text("Group Name")
+                ElevatedCard(
+                    modifier = Modifier
+                        .padding(top = 4.dp)
+                        .fillMaxWidth(),
+                    elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+                ) {
+                    BasicTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    )
                 }
             }
         }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HorizontalFloatingToolbar(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            expanded = true,
+            floatingActionButton = {
+                FloatingToolbarDefaults.VibrantFloatingActionButton(
+                    onClick = {
+                        onSubmit(name)
+                        onDismissRequest()
+                    },
+                    enabled = name.isNotBlank()
+                ) {
+                    Icon(Icons.Default.Check, contentDescription = null)
+                }
+            },
+            content = {}
+        )
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/new/NewCategoryScreen.kt
@@ -1,46 +1,56 @@
 package dev.pandesal.sbp.presentation.categories.new
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.clickable
 import androidx.compose.ui.Alignment
-import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
-import androidx.compose.material3.ToggleButton
-import androidx.compose.material3.ButtonGroupDefaults
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.twotone.DateRange
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import java.math.BigDecimal
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import dev.pandesal.sbp.presentation.categories.CategoriesViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun NewCategoryScreen(
+    groupId: Int,
+    groupName: String,
+    categoriesViewModel: CategoriesViewModel = hiltViewModel(),
+) {
+    val nav = LocalNavigationManager.current
+    NewCategoryScreen(
+        groupId = groupId,
+        groupName = groupName,
+        onSubmit = { name, id ->
+            categoriesViewModel.createCategory(name, id)
+            nav.navigateUp()
+        },
+        onCancel = { nav.navigateUp() },
+        onDismissRequest = { nav.navigateUp() }
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -49,54 +59,46 @@ fun NewCategoryScreen(
     groupId: Int,
     groupName: String,
     initialName: String = "",
-    onSubmit: (
-        name: String,
-        groupId: Int,
-        isGoal: Boolean,
-        target: BigDecimal?,
-        dueDate: LocalDate?
-    ) -> Unit,
+    onSubmit: (name: String, groupId: Int) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
     var name by remember { mutableStateOf(initialName) }
-    var selectedTab by remember { mutableStateOf(0) }
-    var targetAmount by remember { mutableStateOf(BigDecimal.ZERO) }
-    var showDatePicker by remember { mutableStateOf(false) }
-    val datePickerState = rememberDatePickerState()
-    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
 
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        sheetState = sheetState
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.End
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(text = "Add Category to Group: $groupName")
+        Spacer(modifier = Modifier.weight(1f))
 
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(ButtonGroupDefaults.ConnectedSpaceBetween)
-            ) {
-                val options = listOf("Budget", "Goal")
-                options.forEachIndexed { index, label ->
-                    ToggleButton(
-                        checked = selectedTab == index,
-                        onCheckedChange = { selectedTab = index },
-                        modifier = Modifier.weight(1f),
-                        shapes = when (index) {
-                            0 -> ButtonGroupDefaults.connectedLeadingButtonShapes()
-                            options.lastIndex -> ButtonGroupDefaults.connectedTrailingButtonShapes()
-                            else -> ButtonGroupDefaults.connectedMiddleButtonShapes()
-                        }
-                    ) {
-                        Text(label, color = if (selectedTab == index) Color.White else Color.Black)
-                    }
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            IconButton(
+                modifier = Modifier
+                    .height(24.dp)
+                    .padding(4.dp),
+                onClick = {
+                    onCancel()
+                    onDismissRequest()
                 }
+            ) {
+                Icon(Icons.Filled.Close, contentDescription = null)
             }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = "Add Category to Group: $groupName")
 
             Column {
                 Text("Category Name")
@@ -116,94 +118,24 @@ fun NewCategoryScreen(
                 }
             }
 
-            if (selectedTab == 1) {
-                Column(modifier = Modifier.padding(top = 16.dp)) {
-                    Text("Target Amount")
-                    ElevatedCard(
-                        modifier = Modifier
-                            .padding(top = 4.dp)
-                            .fillMaxWidth(),
-                        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
-                    ) {
-                        BasicTextField(
-                            value = targetAmount.toString(),
-                            onValueChange = { targetAmount = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(16.dp)
-                        )
-                    }
-                }
+            Spacer(modifier = Modifier.height(16.dp))
 
-                Column(modifier = Modifier.padding(top = 16.dp)) {
-                    Text("Due Date")
-                    ElevatedCard(
-                        modifier = Modifier
-                            .padding(top = 4.dp)
-                            .fillMaxWidth()
-                            .clickable { showDatePicker = true },
-                        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+            HorizontalFloatingToolbar(
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                expanded = true,
+                floatingActionButton = {
+                    FloatingToolbarDefaults.VibrantFloatingActionButton(
+                        onClick = {
+                            onSubmit(name, groupId)
+                            onDismissRequest()
+                        },
+                        enabled = name.isNotBlank()
                     ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            Text(
-                                selectedDate?.toString() ?: "Select Due Date",
-                                modifier = Modifier.padding(16.dp)
-                            )
-                            Icon(
-                                Icons.TwoTone.DateRange,
-                                contentDescription = null,
-                                modifier = Modifier.padding(end = 8.dp)
-                            )
-                        }
+                        Icon(Icons.Default.Check, contentDescription = null)
                     }
-                }
-            }
-
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                Button(
-                    onClick = {
-                        onSubmit(
-                            name,
-                            groupId,
-                            selectedTab == 1,
-                            if (selectedTab == 1) targetAmount else null,
-                            selectedDate.takeIf { selectedTab == 1 }
-                        )
-                        onDismissRequest()
-                    },
-                    enabled = name.isNotBlank()
-                ) {
-                    Text("Save")
-                }
-                OutlinedButton(onClick = {
-                    onCancel()
-                    onDismissRequest()
-                }) {
-                    Text("Cancel")
-                }
-            }
-        }
-        if (showDatePicker) {
-            DatePickerDialog(
-                onDismissRequest = { showDatePicker = false },
-                confirmButton = {
-                    IconButton(onClick = {
-                        datePickerState.selectedDateMillis?.let { millis ->
-                            selectedDate = Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
-                        }
-                        showDatePicker = false
-                    }) { Icon(Icons.Default.Check, contentDescription = null) }
                 },
-                dismissButton = {
-                    IconButton(onClick = { showDatePicker = false }) { Icon(Icons.Default.Close, contentDescription = null) }
-                }
-            ) {
-                DatePicker(state = datePickerState)
-            }
+                content = {}
+            )
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=24
-versionPatch=0
+versionMinor=25
+versionPatch=1


### PR DESCRIPTION
## Summary
- add navigation destinations for new category and group dialogs
- refactor NewCategory and NewCategoryGroup screens to use floating toolbar
- move Budget/Goal toggle to Set Budget sheet
- bump version to 0.26.0

## Testing
- `sh ./gradlew test` *(fails: Permission denied / network)*