### PR TITLE
Add calendar paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0] - 2025-05-19
+### Added
+- Month navigation for Insights calendar with updated transaction filtering.
+
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import java.time.YearMonth
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.components.TimePeriodDropdown
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
@@ -36,6 +37,7 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
     var cashflowPeriod by remember { mutableStateOf(period) }
     var budgetPeriod by remember { mutableStateOf(period) }
     var netWorthPeriod by remember { mutableStateOf(period) }
+    var calendarMonth by remember { mutableStateOf(YearMonth.now()) }
 
     if (state is InsightsUiState.Initial) {
         SkeletonLoader()
@@ -53,7 +55,12 @@ fun InsightsScreen(viewModel: InsightsViewModel = hiltViewModel()) {
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            CalendarView(data.calendarEvents)
+            val monthEvents = data.calendarEvents.filter { YearMonth.from(it.date) == calendarMonth }
+            CalendarView(
+                events = monthEvents,
+                month = calendarMonth,
+                onMonthChange = { calendarMonth = it }
+            )
 
             Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -12,9 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,16 +28,19 @@ import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.model.CalendarEvent
 import dev.pandesal.sbp.presentation.model.CalendarEventType
 import java.time.DayOfWeek
-import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 fun CalendarView(
     events: List<CalendarEvent>,
-    modifier: Modifier = Modifier
+    month: YearMonth,
+    onMonthChange: (YearMonth) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val today = LocalDate.now()
-    val monthStart = today.withDayOfMonth(1)
-    val daysInMonth = today.lengthOfMonth()
+    val monthStart = month.atDay(1)
+    val daysInMonth = month.lengthOfMonth()
     val firstDayOffset = monthStart.dayOfWeek.ordinal
     val grouped = events.groupBy { it.date }
 
@@ -43,6 +51,24 @@ fun CalendarView(
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text("Transaction Calendar", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { onMonthChange(month.minusMonths(1)) }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = null)
+                }
+                Text(
+                    text = month.month.getDisplayName(TextStyle.FULL, Locale.getDefault()) + " " + month.year,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                IconButton(onClick = { onMonthChange(month.plusMonths(1)) }) {
+                    Icon(Icons.Default.ArrowForward, contentDescription = null)
+                }
+            }
             Spacer(modifier = Modifier.height(8.dp))
 
             Row(

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=25
-versionPatch=1
+versionMinor=26
+versionPatch=0


### PR DESCRIPTION
## Summary
- enable month navigation for Insights calendar
- filter events by the selected month
- bump version to 0.26.0

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*