### PR TITLE
feat: view transactions in creation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.0] - 2025-05-19
+### Added
+- Transactions now open in the New Transaction dialog with read-only fields and options to edit or delete.
+
 ## [0.25.1] - 2025-05-19
 ### Fixed
 - Dialogs now move above the soft keyboard when typing.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -18,7 +18,6 @@ import dev.pandesal.sbp.presentation.insights.InsightsScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTransactionScreen
-import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import dev.pandesal.sbp.presentation.goals.NewGoalScreen
@@ -109,10 +108,9 @@ fun AppNavigation(navController: NavHostController) {
                 dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
             ) { backStackEntry ->
                 val args = backStackEntry.toRoute<NavigationDestination.TransactionDetails>()
-                TransactionDetailsScreen(
+                NewTransactionScreen(
                     transactionId = args.transactionId,
-                    onDismiss = { navController.navigateUp() },
-                    onSave = { navController.navigateUp() }
+                    readOnly = true
                 )
             }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.twotone.ArrowDropDown
 import androidx.compose.material.icons.twotone.DateRange
 import androidx.compose.material.icons.twotone.Favorite
@@ -70,6 +72,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.pandesal.sbp.domain.model.Category
 import dev.pandesal.sbp.domain.model.CategoryGroup
@@ -87,20 +90,31 @@ import kotlinx.coroutines.delay
 
 @Composable
 fun NewTransactionScreen(
+    transactionId: String? = null,
+    readOnly: Boolean = false,
     viewModel: NewTransactionsViewModel = hiltViewModel()
 ) {
     val uiState = viewModel.uiState.collectAsState()
     val navManager = LocalNavigationManager.current
 
+    LaunchedEffect(transactionId) {
+        transactionId?.let { viewModel.loadTransaction(it) }
+    }
+
     if (uiState.value is NewTransactionUiState.Initial) {
         SkeletonLoader()
     } else if (uiState.value is NewTransactionUiState.Success) {
         val state = uiState.value as NewTransactionUiState.Success
+        var editable by remember { mutableStateOf(!readOnly) }
+        var showDelete by remember { mutableStateOf(false) }
         NewTransactionScreen(
-            state.groupedCategories,
-            state.accounts,
-            state.transaction,
-            state.merchants,
+            groupedCategories = state.groupedCategories,
+            accounts = state.accounts,
+            transaction = state.transaction,
+            merchants = state.merchants,
+            editable = editable,
+            onEdit = { editable = true },
+            onDelete = { showDelete = true },
             onSave = {
                 viewModel.saveTransaction {
                     navManager.navigateUp()
@@ -113,6 +127,35 @@ fun NewTransactionScreen(
                 viewModel.updateTransaction(it)
             }
         )
+
+        if (showDelete) {
+            androidx.compose.material3.AlertDialog(
+                onDismissRequest = { showDelete = false },
+                confirmButton = {
+                    androidx.compose.material3.Button(onClick = {
+                        viewModel.deleteTransaction(state.transaction) {
+                            navManager.navigateUp()
+                        }
+                        showDelete = false
+                    }) { androidx.compose.material3.Text("Delete") }
+                },
+                dismissButton = {
+                    androidx.compose.material3.Button(onClick = { showDelete = false }) {
+                        androidx.compose.material3.Text("Cancel")
+                    }
+                },
+                title = { androidx.compose.material3.Text("Delete Transaction") },
+                text = { androidx.compose.material3.Text("Are you sure you want to delete this transaction?") }
+            )
+        }
+        if (!editable) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.Transparent)
+                    .pointerInput(Unit) {}
+            )
+        }
     }
 }
 
@@ -124,6 +167,9 @@ private fun NewTransactionScreen(
     accounts: List<Account>,
     transaction: Transaction,
     merchants: List<String>,
+    editable: Boolean,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
     onSave: (Transaction) -> Unit,
     onCancel: () -> Unit,
     onUpdate: (Transaction) -> Unit
@@ -176,15 +222,16 @@ private fun NewTransactionScreen(
         showButtons = true
     }
 
-    Column(
-        modifier = Modifier
-            .background(Color.Transparent)
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(16.dp)
-            .imePadding(),
-        verticalArrangement = Arrangement.Bottom
-    ) {
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .background(Color.Transparent)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+                .imePadding(),
+            verticalArrangement = Arrangement.Bottom
+        ) {
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -200,12 +247,26 @@ private fun NewTransactionScreen(
                     defaultElevation = 16.dp
                 ),
             ) {
-                IconButton(
-                    modifier = Modifier
-                        .size(24.dp)
-                        .padding(4.dp),
-                    onClick = { onCancel() }) {
-                    Icon(Icons.Filled.Close, "Localized description")
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    IconButton(
+                        modifier = Modifier
+                            .size(24.dp)
+                            .padding(4.dp),
+                        onClick = { onCancel() }) {
+                        Icon(Icons.Filled.Close, "Localized description")
+                    }
+                    if (editable) {
+                        IconButton(onClick = { onSave(transaction) }) {
+                            Icon(Icons.Filled.Check, null)
+                        }
+                    } else {
+                        IconButton(onClick = onEdit) {
+                            Icon(Icons.Filled.Edit, null)
+                        }
+                        IconButton(onClick = onDelete) {
+                            Icon(Icons.Filled.Delete, null)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -153,4 +153,23 @@ class NewTransactionsViewModel @Inject constructor(
             }
         }
     }
+
+    fun loadTransaction(id: String) {
+        viewModelScope.launch {
+            transactionUseCase.getTransactionById(id).collect { tx ->
+                _transaction.value = tx
+            }
+        }
+    }
+
+    fun deleteTransaction(transaction: Transaction, onResult: (Boolean) -> Unit = {}) {
+        viewModelScope.launch {
+            runCatching { transactionUseCase.delete(transaction) }
+                .onSuccess { onResult(true) }
+                .onFailure {
+                    _uiState.value = NewTransactionUiState.Error("Delete failed: ${it.localizedMessage}")
+                    onResult(false)
+                }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=25
-versionPatch=1
+versionMinor=26
+versionPatch=0


### PR DESCRIPTION
## Summary
- reuse New Transaction dialog for viewing existing entries
- allow editing or deleting the transaction from this dialog
- bump version to 0.26.0

## Testing
- `sh ./gradlew test` *(fails: No route to host)*