### PR TITLE
Add screen for recurring transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-05-19
+### Added
+- View upcoming recurring transactions in a new screen.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
 class RecurringTransactionUseCase @Inject constructor(
     private val repository: RecurringTransactionRepositoryInterface
 ) {
+    fun getRecurringTransactions(): Flow<List<RecurringTransaction>> =
+        repository.getRecurringTransactions()
     fun getUpcomingNotifications(
         currentDate: LocalDate = LocalDate.now(),
         withinDays: Long = 7
@@ -33,7 +35,7 @@ class RecurringTransactionUseCase @Inject constructor(
         }
     }
 
-    private fun nextDueDate(rec: dev.pandesal.sbp.domain.model.RecurringTransaction, fromDate: LocalDate): LocalDate {
+    fun nextDueDate(rec: RecurringTransaction, fromDate: LocalDate = LocalDate.now()): LocalDate {
         var due = rec.startDate
         while (!due.isAfter(fromDate)) {
             due = when (rec.interval) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -21,6 +21,7 @@ import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsScreen
+import dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsScreen
 import dev.pandesal.sbp.presentation.categories.budget.SetBudgetScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
@@ -54,6 +55,8 @@ sealed class NavigationDestination() {
     data object NewGoal : NavigationDestination()
     @Serializable
     data object NewRecurringTransaction : NavigationDestination()
+    @Serializable
+    data object RecurringTransactions : NavigationDestination()
     @Serializable
     data object NewCategoryGroup : NavigationDestination()
     @Serializable
@@ -136,6 +139,10 @@ fun AppNavigation(navController: NavHostController) {
                 dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
             ) {
                 NewRecurringTransactionScreen()
+            }
+
+            composable<NavigationDestination.RecurringTransactions> {
+                dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsScreen()
             }
 
             dialog<NavigationDestination.TransactionDetails>(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsScreen.kt
@@ -1,0 +1,66 @@
+package dev.pandesal.sbp.presentation.transactions.recurring
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.domain.model.RecurringInterval
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import dev.pandesal.sbp.presentation.NavigationDestination
+import java.time.LocalDate
+
+@Composable
+fun RecurringTransactionsScreen(
+    viewModel: RecurringTransactionsViewModel = hiltViewModel()
+) {
+    val navManager = LocalNavigationManager.current
+    val state = viewModel.uiState.collectAsState()
+
+    if (state.value is RecurringTransactionsUiState.Success) {
+        val transactions = (state.value as RecurringTransactionsUiState.Success).transactions
+        RecurringTransactionsContent(transactions, nextDueDate = {
+            viewModel.nextDueDate(it, LocalDate.now())
+        }) { rec ->
+            navManager.navigate(
+                NavigationDestination.TransactionDetails(rec.transaction.id)
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecurringTransactionsContent(
+    transactions: List<RecurringTransaction>,
+    nextDueDate: (RecurringTransaction) -> LocalDate,
+    onItemClick: (RecurringTransaction) -> Unit
+) {
+    LazyColumn {
+        items(transactions, key = { it.transaction.id }) { rec ->
+            Column(
+                modifier = Modifier
+                    .clickable { onItemClick(rec) }
+                    .padding(16.dp)
+            ) {
+                Text(rec.transaction.name, style = MaterialTheme.typography.titleMedium)
+                val interval = when (rec.interval) {
+                    RecurringInterval.DAILY -> "Daily"
+                    RecurringInterval.WEEKLY -> "Weekly"
+                    RecurringInterval.MONTHLY -> "Monthly"
+                    RecurringInterval.AFTER_CUTOFF -> "Monthly after cutoff"
+                }
+                Text(interval, style = MaterialTheme.typography.bodySmall)
+                val nextDate = nextDueDate(rec)
+                Text("Next on $nextDate", style = MaterialTheme.typography.bodySmall)
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsUiState.kt
@@ -1,0 +1,9 @@
+package dev.pandesal.sbp.presentation.transactions.recurring
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+
+sealed interface RecurringTransactionsUiState {
+    data object Loading : RecurringTransactionsUiState
+    data class Success(val transactions: List<RecurringTransaction>) : RecurringTransactionsUiState
+    data class Error(val message: String) : RecurringTransactionsUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurring/RecurringTransactionsViewModel.kt
@@ -1,0 +1,29 @@
+package dev.pandesal.sbp.presentation.transactions.recurring
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecurringTransactionsViewModel @Inject constructor(
+    private val useCase: RecurringTransactionUseCase
+) : ViewModel() {
+
+    private val _uiState =
+        MutableStateFlow<RecurringTransactionsUiState>(RecurringTransactionsUiState.Loading)
+    val uiState: StateFlow<RecurringTransactionsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            useCase.getRecurringTransactions().collect { list ->
+                _uiState.value = RecurringTransactionsUiState.Success(list)
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/RecurringTransactionsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/RecurringTransactionsViewModelTest.kt
@@ -1,0 +1,42 @@
+package dev.pandesal.sbp
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import dev.pandesal.sbp.fakes.FakeRecurringTransactionRepository
+import dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsUiState
+import dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecurringTransactionsViewModelTest {
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val repository = FakeRecurringTransactionRepository()
+    private val useCase = RecurringTransactionUseCase(repository)
+
+    @Test
+    fun uiStateEmitsRecurring() = runTest {
+        val tx = Transaction(
+            name = "Bill",
+            amount = BigDecimal.ONE,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            transactionType = TransactionType.OUTFLOW
+        )
+        repository.recurringFlow.value = listOf(RecurringTransaction(tx, dev.pandesal.sbp.domain.model.RecurringInterval.MONTHLY))
+        val vm = RecurringTransactionsViewModel(useCase)
+        advanceUntilIdle()
+        val state = vm.uiState.value as RecurringTransactionsUiState.Success
+        assertEquals(1, state.transactions.size)
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/fakes/FakeRecurringTransactionRepository.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/FakeRecurringTransactionRepository.kt
@@ -1,0 +1,19 @@
+package dev.pandesal.sbp.fakes
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeRecurringTransactionRepository : RecurringTransactionRepositoryInterface {
+    val recurringFlow = MutableStateFlow<List<RecurringTransaction>>(emptyList())
+    val inserted = mutableListOf<RecurringTransaction>()
+
+    override fun getRecurringTransactions(): Flow<List<RecurringTransaction>> = recurringFlow
+
+    override suspend fun addRecurringTransaction(transaction: RecurringTransaction) {
+        inserted.add(transaction)
+    }
+
+    override suspend fun removeRecurringTransaction(transaction: RecurringTransaction) {}
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=28
+versionMinor=29
 versionPatch=0


### PR DESCRIPTION
## Summary
- show upcoming recurring transactions list
- compute next due dates using use case
- allow navigating to transaction details
- bump version to 0.29.0

## Testing
- `gradle test` *(fails: Gradle wrapper unable to download distribution)*