### PR TITLE
Add details view for recurring transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-05-19
+### Added
+- View recurring transaction details with edit and delete actions.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/data/dao/RecurringTransactionDao.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/dao/RecurringTransactionDao.kt
@@ -12,6 +12,9 @@ interface RecurringTransactionDao {
     @Query("SELECT * FROM recurring_transactions")
     fun getRecurringTransactions(): Flow<List<RecurringTransactionEntity>>
 
+    @Query("SELECT * FROM recurring_transactions WHERE id = :id")
+    fun getRecurringTransactionById(id: String): Flow<RecurringTransactionEntity>
+
     @Upsert
     suspend fun insert(value: RecurringTransactionEntity)
 

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/RecurringTransactionRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/RecurringTransactionRepository.kt
@@ -17,6 +17,9 @@ class RecurringTransactionRepository @Inject constructor(
     override fun getRecurringTransactions(): Flow<List<RecurringTransaction>> =
         dao.getRecurringTransactions().map { list -> list.map { it.toDomainModel() } }
 
+    override fun getRecurringTransactionById(id: String): Flow<RecurringTransaction> =
+        dao.getRecurringTransactionById(id).map { it.toDomainModel() }
+
     override suspend fun addRecurringTransaction(transaction: RecurringTransaction) {
         dao.insert(transaction.toEntity())
     }

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/RecurringTransactionRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/RecurringTransactionRepositoryInterface.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface RecurringTransactionRepositoryInterface {
     fun getRecurringTransactions(): Flow<List<RecurringTransaction>>
+    fun getRecurringTransactionById(id: String): Flow<RecurringTransaction>
     suspend fun addRecurringTransaction(transaction: RecurringTransaction)
     suspend fun removeRecurringTransaction(transaction: RecurringTransaction)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
@@ -13,6 +13,8 @@ import javax.inject.Inject
 class RecurringTransactionUseCase @Inject constructor(
     private val repository: RecurringTransactionRepositoryInterface
 ) {
+    fun getRecurringTransactionById(id: String): Flow<RecurringTransaction> =
+        repository.getRecurringTransactionById(id)
     fun getUpcomingNotifications(
         currentDate: LocalDate = LocalDate.now(),
         withinDays: Long = 7

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -21,6 +21,7 @@ import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTransactionScreen
 import dev.pandesal.sbp.presentation.transactions.details.TransactionDetailsScreen
+import dev.pandesal.sbp.presentation.transactions.recurringdetails.RecurringTransactionDetailsScreen
 import dev.pandesal.sbp.presentation.categories.budget.SetBudgetScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
@@ -62,6 +63,8 @@ sealed class NavigationDestination() {
     data class NewCategory(val groupId: Int, val groupName: String) : NavigationDestination()
     @Serializable
     data class TransactionDetails(val transactionId: String) : NavigationDestination()
+    @Serializable
+    data class RecurringTransactionDetails(val id: String) : NavigationDestination()
 
 }
 
@@ -146,6 +149,13 @@ fun AppNavigation(navController: NavHostController) {
                     transactionId = args.transactionId,
                     readOnly = true
                 )
+            }
+
+            dialog<NavigationDestination.RecurringTransactionDetails>(
+                dialogProperties = DialogProperties(usePlatformDefaultWidth = false)
+            ) { backStackEntry ->
+                val args = backStackEntry.toRoute<NavigationDestination.RecurringTransactionDetails>()
+                RecurringTransactionDetailsScreen(id = args.id)
             }
 
             composable<NavigationDestination.Notifications> {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsScreen.kt
@@ -1,0 +1,140 @@
+package dev.pandesal.sbp.presentation.transactions.recurringdetails
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingToolbarDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun RecurringTransactionDetailsScreen(
+    id: String,
+    viewModel: RecurringTransactionDetailsViewModel = hiltViewModel()
+) {
+    val navManager = LocalNavigationManager.current
+
+    LaunchedEffect(id) { viewModel.loadTransaction(id) }
+
+    val txState = viewModel.transaction.collectAsState()
+    val rec = txState.value ?: return
+
+    var editable by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+            .imePadding(),
+        verticalArrangement = Arrangement.Top
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        ElevatedCard(
+            modifier = Modifier.align(Alignment.End),
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            IconButton(
+                modifier = Modifier
+                    .height(24.dp)
+                    .padding(4.dp),
+                onClick = { navManager.navigateUp() }
+            ) {
+                Icon(Icons.Filled.Close, contentDescription = null)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ElevatedCard(
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = rec.transaction.name,
+                    onValueChange = { viewModel.update(rec.copy(transaction = rec.transaction.copy(name = it))) },
+                    enabled = editable,
+                    label = { Text("Name") }
+                )
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    value = rec.transaction.amount.toPlainString(),
+                    onValueChange = {},
+                    enabled = false,
+                    label = { Text("Amount") }
+                )
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    value = rec.interval.name,
+                    onValueChange = {},
+                    enabled = false,
+                    label = { Text("Interval") }
+                )
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+                    value = rec.startDate.toString(),
+                    onValueChange = {},
+                    enabled = false,
+                    label = { Text("Start Date") }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HorizontalFloatingToolbar(
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            expanded = true,
+            floatingActionButton = {
+                FloatingToolbarDefaults.VibrantFloatingActionButton(
+                    onClick = {
+                        if (editable) viewModel.save { if (it) navManager.navigateUp() } else editable = true
+                    }
+                ) {
+                    Icon(if (editable) Icons.Default.Check else Icons.Default.Edit, contentDescription = null)
+                }
+            },
+            content = {
+                if (!editable) {
+                    IconButton(onClick = { viewModel.delete { if (it) navManager.navigateUp() } }) {
+                        Icon(Icons.Default.Delete, contentDescription = null)
+                    }
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsViewModel.kt
@@ -1,0 +1,51 @@
+package dev.pandesal.sbp.presentation.transactions.recurringdetails
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RecurringTransactionDetailsViewModel @Inject constructor(
+    private val useCase: RecurringTransactionUseCase
+) : ViewModel() {
+
+    private val _transaction = MutableStateFlow<RecurringTransaction?>(null)
+    val transaction: StateFlow<RecurringTransaction?> = _transaction.asStateFlow()
+
+    fun loadTransaction(id: String) {
+        viewModelScope.launch {
+            useCase.getRecurringTransactionById(id).collect {
+                _transaction.value = it
+            }
+        }
+    }
+
+    fun delete(onResult: (Boolean) -> Unit = {}) {
+        val tx = _transaction.value ?: return
+        viewModelScope.launch {
+            runCatching { useCase.removeRecurringTransaction(tx) }
+                .onSuccess { onResult(true) }
+                .onFailure { onResult(false) }
+        }
+    }
+
+    fun update(transaction: RecurringTransaction) {
+        _transaction.value = transaction
+    }
+
+    fun save(onResult: (Boolean) -> Unit = {}) {
+        val tx = _transaction.value ?: return
+        viewModelScope.launch {
+            runCatching { useCase.addRecurringTransaction(tx) }
+                .onSuccess { onResult(true) }
+                .onFailure { onResult(false) }
+        }
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/RecurringTransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/RecurringTransactionDetailsViewModelTest.kt
@@ -1,0 +1,68 @@
+package dev.pandesal.sbp
+
+import dev.pandesal.sbp.domain.model.RecurringInterval
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import dev.pandesal.sbp.fakes.FakeRecurringTransactionRepository
+import dev.pandesal.sbp.presentation.transactions.recurringdetails.RecurringTransactionDetailsViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RecurringTransactionDetailsViewModelTest {
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val repository = FakeRecurringTransactionRepository()
+    private val useCase = RecurringTransactionUseCase(repository)
+
+    @Test
+    fun loadTransactionEmitsValue() = runTest {
+        val tx = RecurringTransaction(
+            transaction = Transaction(
+                name = "Bill",
+                amount = BigDecimal.ONE,
+                createdAt = LocalDate.now(),
+                updatedAt = LocalDate.now(),
+                transactionType = TransactionType.OUTFLOW
+            ),
+            interval = RecurringInterval.MONTHLY,
+            startDate = LocalDate.now()
+        )
+        repository.transactionsFlow.value = listOf(tx)
+
+        val vm = RecurringTransactionDetailsViewModel(useCase)
+        vm.loadTransaction(tx.transaction.id)
+        advanceUntilIdle()
+        assertEquals(tx, vm.transaction.value)
+    }
+
+    @Test
+    fun deleteCallsRepository() = runTest {
+        val tx = RecurringTransaction(
+            transaction = Transaction(
+                name = "Bill",
+                amount = BigDecimal.ONE,
+                createdAt = LocalDate.now(),
+                updatedAt = LocalDate.now(),
+                transactionType = TransactionType.OUTFLOW
+            ),
+            interval = RecurringInterval.MONTHLY,
+            startDate = LocalDate.now()
+        )
+        repository.transactionsFlow.value = listOf(tx)
+        val vm = RecurringTransactionDetailsViewModel(useCase)
+        vm.loadTransaction(tx.transaction.id)
+        vm.delete()
+        advanceUntilIdle()
+        assertEquals(listOf(tx), repository.deleted)
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/fakes/FakeRecurringTransactionRepository.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/FakeRecurringTransactionRepository.kt
@@ -1,0 +1,26 @@
+package dev.pandesal.sbp.fakes
+
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeRecurringTransactionRepository : RecurringTransactionRepositoryInterface {
+    val transactionsFlow = MutableStateFlow<List<RecurringTransaction>>(emptyList())
+    val inserted = mutableListOf<RecurringTransaction>()
+    val deleted = mutableListOf<RecurringTransaction>()
+
+    override fun getRecurringTransactions(): Flow<List<RecurringTransaction>> = transactionsFlow
+
+    override fun getRecurringTransactionById(id: String): Flow<RecurringTransaction> =
+        flowOf(transactionsFlow.value.first { it.transaction.id == id })
+
+    override suspend fun addRecurringTransaction(transaction: RecurringTransaction) {
+        inserted.add(transaction)
+    }
+
+    override suspend fun removeRecurringTransaction(transaction: RecurringTransaction) {
+        deleted.add(transaction)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=28
+versionMinor=29
 versionPatch=0


### PR DESCRIPTION
## Summary
- extend recurring transaction DAO, repository, and interface with get-by-id
- add RecurringTransactionDetailsViewModel and screen
- wire up navigation for recurring transaction details
- provide fake repository and tests for the new ViewModel
- bump version to 0.29.0

## Testing
- `gradle test` *(fails: Plugin com.android.application not found)*