### PR TITLE
Update contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 These guidelines apply to the entire repository.
 
 - **Commit Messages**: Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
-- **Changelog**: Update `CHANGELOG.md` with any user-facing change under the `Unreleased` section following the Keep a Changelog format.
+- **Changelog**: Add entries to `CHANGELOG.md` under the current version heading. Do not use an `Unreleased` section.
+- **Versioning**: Bump the project's semantic version numbers in each PR. Choose a minor or patch increment as appropriate and reset the patch when increasing the minor version.
 - **Testing**: Run `./gradlew test` before committing any code changes.
 - **Nested Instructions**: Check for additional `AGENTS.md` files in subdirectories when modifying files within them.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2025-05-19
+### Changed
+- Clarified contribution guidelines on versioning and changelog entries.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=28
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- clarify changelog instructions
- require version updates every PR
- bump patch version to 0.28.1

## Testing
- `./gradlew test` *(fails: NoRouteToHostException while downloading Gradle wrapper)*