### PR TITLE
Fix read-only transaction controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.1] - 2025-05-19
+### Fixed
+- Close, edit and delete buttons now work in read-only transaction view.
+- Close button layout matches other dialogs.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -150,14 +150,6 @@ fun NewTransactionScreen(
                 text = { Text("Are you sure you want to delete this transaction?") }
             )
         }
-        if (!editable) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Transparent)
-                    .pointerInput(Unit) {}
-            )
-        }
     }
 }
 
@@ -271,7 +263,7 @@ private fun NewTransactionScreen(
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         IconButton(
                             modifier = Modifier
-                                .size(24.dp)
+                                .height(24.dp)
                                 .padding(4.dp),
                             onClick = { onCancel() }) {
                             Icon(Icons.Filled.Close, "Localized description")
@@ -312,6 +304,7 @@ private fun NewTransactionScreen(
                             if (transaction.amount == BigDecimal.ZERO) "" else transaction.amount.toPlainString()
 
                         BasicTextField(
+                            enabled = editable,
                             value = amountText,
                             onValueChange = { input ->
                                 val newAmount = input.toBigDecimalOrNull() ?: BigDecimal.ZERO
@@ -372,7 +365,7 @@ private fun NewTransactionScreen(
                                 modifier = Modifier
                                     .padding(top = 4.dp)
                                     .fillMaxWidth()
-                                    .clickable { expanded = true }
+                                    .clickable(enabled = editable) { expanded = true }
                             ) {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
@@ -420,7 +413,7 @@ private fun NewTransactionScreen(
                                                             style = MaterialTheme.typography.headlineLarge,
                                                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                                                             modifier = Modifier
-                                                                .clickable {
+                                                                .clickable(enabled = editable) {
                                                                     onUpdate(
                                                                         transaction.copy(
                                                                             category = item
@@ -437,7 +430,7 @@ private fun NewTransactionScreen(
                                                             color = MaterialTheme.colorScheme.onSurface,
                                                             modifier = Modifier
                                                                 .weight(1f)
-                                                                .clickable {
+                                                                .clickable(enabled = editable) {
                                                                     onUpdate(
                                                                         transaction.copy(
                                                                             category = item
@@ -469,7 +462,7 @@ private fun NewTransactionScreen(
                                     modifier = Modifier
                                         .padding(top = 4.dp)
                                         .fillMaxWidth()
-                                        .clickable { fromAccountExpanded = true }
+                                        .clickable(enabled = editable) { fromAccountExpanded = true }
                                 ) {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
@@ -533,6 +526,7 @@ private fun NewTransactionScreen(
                                         modifier = Modifier.fillMaxWidth()
                                     ) {
                                         BasicTextField(
+                                            enabled = editable,
                                             value = transaction.merchantName.orEmpty(),
                                             onValueChange = { onUpdate(transaction.copy(merchantName = it)) },
                                             modifier = Modifier
@@ -547,7 +541,7 @@ private fun NewTransactionScreen(
                                             modifier = Modifier
                                                 .padding(end = 8.dp)
                                                 .size(24.dp)
-                                                .clickable { merchantExpanded = true }
+                                                .clickable(enabled = editable) { merchantExpanded = true }
                                         )
                                     }
                                 }
@@ -561,7 +555,7 @@ private fun NewTransactionScreen(
                                                 text = item,
                                                 modifier = Modifier
                                                     .fillMaxWidth()
-                                                    .clickable {
+                                                    .clickable(enabled = editable) {
                                                         onUpdate(transaction.copy(merchantName = item))
                                                         merchantExpanded = false
                                                     }
@@ -582,7 +576,7 @@ private fun NewTransactionScreen(
                                     modifier = Modifier
                                         .padding(top = 4.dp)
                                         .fillMaxWidth()
-                                        .clickable { toAccountExpanded = true }
+                                        .clickable(enabled = editable) { toAccountExpanded = true }
                                 ) {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
@@ -614,7 +608,7 @@ private fun NewTransactionScreen(
                                                 text = account.name,
                                                 modifier = Modifier
                                                     .fillMaxWidth()
-                                                    .clickable {
+                                                    .clickable(enabled = editable) {
                                                         onUpdate(transaction.copy(to = account.id, toAccountName = account.name))
                                                         toAccountExpanded = false
                                                     }
@@ -634,7 +628,7 @@ private fun NewTransactionScreen(
                                 modifier = Modifier
                                     .padding(top = 4.dp)
                                     .fillMaxWidth()
-                                    .clickable { showDatePicker.value = true }) {
+                                    .clickable(enabled = editable) { showDatePicker.value = true }) {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
                                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -658,10 +652,11 @@ private fun NewTransactionScreen(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(top = 8.dp)
-                                    .clickable { isRecurring = !isRecurring },
+                                    .clickable(enabled = editable) { isRecurring = !isRecurring },
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 Checkbox(
+                                    enabled = editable,
                                     checked = isRecurring,
                                     onCheckedChange = { isRecurring = it }
                                 )
@@ -677,7 +672,7 @@ private fun NewTransactionScreen(
                                     modifier = Modifier
                                         .padding(top = 4.dp)
                                         .fillMaxWidth()
-                                        .clickable { recurringExpanded = true }
+                                        .clickable(enabled = editable) { recurringExpanded = true }
                                 ) {
                                     Row(
                                         verticalAlignment = Alignment.CenterVertically,
@@ -721,6 +716,7 @@ private fun NewTransactionScreen(
 
                                 if (selectedInterval == RecurringInterval.AFTER_CUTOFF) {
                                     OutlinedTextField(
+                                        enabled = editable,
                                         value = cutoffDays.toString(),
                                         onValueChange = { input ->
                                             cutoffDays = input.toIntOrNull() ?: 21
@@ -773,6 +769,7 @@ private fun NewTransactionScreen(
 
                             options.forEachIndexed { index, label ->
                                 ToggleButton(
+                                    enabled = editable,
                                     checked = selectedIndex == index,
                                     onCheckedChange = {
                                         selectedIndex = index

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=28
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- make close, edit, and delete work in read-only transactions
- tidy the close button layout
- bump version to 0.28.1
- document changes in the changelog

## Testing
- `./gradlew test` *(fails: Could not download gradle-8.13-bin.zip)*