### PR TITLE
Show allocation summary on categories pie chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-05-19
+### Added
+- Display allocated and unallocated amounts above the Categories pie chart.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -79,6 +79,7 @@ import dev.pandesal.sbp.presentation.categories.new.NewCategoryGroupScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryScreen
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.categories.components.CategoryBudgetPieChart
+import dev.pandesal.sbp.presentation.home.components.BudgetSummaryHeader
 import dev.pandesal.sbp.presentation.goals.GoalsViewModel
 import dev.pandesal.sbp.domain.model.Goal
 import dev.pandesal.sbp.presentation.goals.GoalsUiState
@@ -625,6 +626,14 @@ fun CategoriesScreen(
                 Text(
                     text = "Categories & Budgets",
                     style = MaterialTheme.typography.titleLargeEmphasized
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                BudgetSummaryHeader(
+                    unassigned = state.budgetSummary.unassigned,
+                    assigned = state.budgetSummary.assigned,
+                    currency = "PHP"
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesUiState.kt
@@ -4,6 +4,7 @@ import dev.pandesal.sbp.domain.model.Category
 import dev.pandesal.sbp.domain.model.CategoryGroup
 import dev.pandesal.sbp.domain.model.CategoryWithBudget
 import dev.pandesal.sbp.domain.model.MonthlyBudget
+import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
@@ -14,6 +15,7 @@ sealed interface CategoriesUiState {
         val categoryGroups: List<CategoryGroup>,
         val categoriesWithBudget: List<CategoryWithBudget>,
         val showTemplatePrompt: Boolean,
+        val budgetSummary: BudgetSummaryUiModel,
     ) : CategoriesUiState
     data class Error(val errorMessage: String) : CategoriesUiState
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/BudgetSummaryHeader.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/BudgetSummaryHeader.kt
@@ -20,19 +20,20 @@ fun BudgetSummaryHeader(unassigned: Double, assigned: Double, currency: String =
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column {
-            Text("Unassigned", style = MaterialTheme.typography.labelMedium)
+            Text("Unallocated", style = MaterialTheme.typography.labelMedium)
             val symbol = currency.currencySymbol()
             Text(
                 text = "$symbol${unassigned.format()}",
                 style = MaterialTheme.typography.displayMedium.copy(fontWeight = FontWeight.Bold)
             )
         }
-//        Column {
-//            Text("Assigned", style = MaterialTheme.typography.labelMedium)
-//            Text(
-//                text = "₱${assigned.format()}",
-//                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-//            )
-//        }
+        Column {
+            Text("Allocated", style = MaterialTheme.typography.labelMedium)
+            val symbol = currency.currencySymbol()
+            Text(
+                text = "$symbol${assigned.format()}",
+                style = MaterialTheme.typography.displayMedium.copy(fontWeight = FontWeight.Bold)
+            )
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=28
+versionMinor=29
 versionPatch=0


### PR DESCRIPTION
## Summary
- show allocated and unallocated money above the categories pie chart
- adjust viewmodel to provide zero-based budgeting data
- bump version to 0.29.0

## Testing
- `./gradlew test` *(fails: No route to host)*