### PR TITLE
feat: show allocation summary above pie chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-05-19
+### Added
+- Display allocated and unallocated summary above budgets pie chart in Categories screen.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -84,6 +84,7 @@ import dev.pandesal.sbp.domain.model.Goal
 import dev.pandesal.sbp.presentation.goals.GoalsUiState
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.NavigationDestination
+import dev.pandesal.sbp.presentation.home.components.BudgetSummaryHeader
 import java.time.temporal.ChronoUnit
 import java.time.LocalDate
 import kotlinx.coroutines.launch
@@ -625,6 +626,13 @@ fun CategoriesScreen(
                 Text(
                     text = "Categories & Budgets",
                     style = MaterialTheme.typography.titleLargeEmphasized
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                BudgetSummaryHeader(
+                    unassigned = state.budgetSummary.unassigned,
+                    assigned = state.budgetSummary.assigned
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesUiState.kt
@@ -4,6 +4,7 @@ import dev.pandesal.sbp.domain.model.Category
 import dev.pandesal.sbp.domain.model.CategoryGroup
 import dev.pandesal.sbp.domain.model.CategoryWithBudget
 import dev.pandesal.sbp.domain.model.MonthlyBudget
+import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
@@ -14,6 +15,7 @@ sealed interface CategoriesUiState {
         val categoryGroups: List<CategoryGroup>,
         val categoriesWithBudget: List<CategoryWithBudget>,
         val showTemplatePrompt: Boolean,
+        val budgetSummary: BudgetSummaryUiModel,
     ) : CategoriesUiState
     data class Error(val errorMessage: String) : CategoriesUiState
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesViewModel.kt
@@ -1,8 +1,5 @@
 package dev.pandesal.sbp.presentation.categories
 
-import android.util.Log
-import androidx.collection.mutableIntListOf
-import androidx.collection.mutableIntSetOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -11,12 +8,12 @@ import dev.pandesal.sbp.domain.model.CategoryGroup
 import dev.pandesal.sbp.domain.model.MonthlyBudget
 import dev.pandesal.sbp.domain.model.TransactionType
 import dev.pandesal.sbp.domain.usecase.CategoryUseCase
+import dev.pandesal.sbp.domain.usecase.ZeroBasedBudgetUseCase
+import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
 import java.time.YearMonth
@@ -24,7 +21,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CategoriesViewModel @Inject constructor(
-    private val useCase: CategoryUseCase
+    private val useCase: CategoryUseCase,
+    private val zeroBasedBudgetUseCase: ZeroBasedBudgetUseCase
 ) : ViewModel() {
 
     private val _uiState: MutableStateFlow<CategoriesUiState> = MutableStateFlow(CategoriesUiState.Initial)
@@ -38,13 +36,15 @@ class CategoriesViewModel @Inject constructor(
         viewModelScope.launch {
             combine(
                 useCase.getCategoryGroups(),
-                useCase.getCategoriesWithLatestBudget()
-            ) { groups, categories ->
+                useCase.getCategoriesWithLatestBudget(),
+                zeroBasedBudgetUseCase.getBudgetSummary()
+            ) { groups, categories, summary ->
                 val filtered = categories.filter { it.category.categoryType != TransactionType.INFLOW }
                 CategoriesUiState.Success(
                     categoryGroups = groups.filter { it.name.lowercase() != "inflow" && it.name.lowercase() != "transfers" },
                     categoriesWithBudget = filtered,
-                    showTemplatePrompt = categories.none { it.category.categoryType == TransactionType.OUTFLOW }
+                    showTemplatePrompt = categories.none { it.category.categoryType == TransactionType.OUTFLOW },
+                    budgetSummary = summary.toUiModel()
                 )
             }.collect { state ->
                 _uiState.value = state
@@ -167,5 +167,7 @@ class CategoriesViewModel @Inject constructor(
         }
     }
 
-
 }
+
+private fun dev.pandesal.sbp.domain.model.BudgetSummary.toUiModel(): BudgetSummaryUiModel =
+    BudgetSummaryUiModel(assigned, unassigned)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/BudgetSummaryHeader.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/BudgetSummaryHeader.kt
@@ -20,19 +20,19 @@ fun BudgetSummaryHeader(unassigned: Double, assigned: Double, currency: String =
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column {
-            Text("Unassigned", style = MaterialTheme.typography.labelMedium)
+            Text("Unallocated", style = MaterialTheme.typography.labelMedium)
             val symbol = currency.currencySymbol()
             Text(
                 text = "$symbol${unassigned.format()}",
                 style = MaterialTheme.typography.displayMedium.copy(fontWeight = FontWeight.Bold)
             )
         }
-//        Column {
-//            Text("Assigned", style = MaterialTheme.typography.labelMedium)
-//            Text(
-//                text = "₱${assigned.format()}",
-//                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-//            )
-//        }
+        Column {
+            Text("Allocated", style = MaterialTheme.typography.labelMedium)
+            Text(
+                text = "$symbol${assigned.format()}",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+            )
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=28
+versionMinor=29
 versionPatch=0


### PR DESCRIPTION
## Summary
- show unallocated and allocated money above the pie chart in Categories
- bump version to 0.29.0

## Testing
- `./gradlew test` *(fails: No route to host)*