### PR TITLE
Add new loan types and credit card fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.0] - 2025-05-19
+### Added
+- New loan account types for assets and spending.
+- Accounts can record whether a loan is from an institution or a person.
+- Credit card accounts now include an optional credit limit.
+
 ## [0.28.0] - 2025-05-19
 ### Added
 - Set Budget now opens as a dialog similar to New Transaction.

--- a/app/src/main/java/dev/pandesal/sbp/data/local/Account.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/Account.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import dev.pandesal.sbp.domain.model.Account
 import dev.pandesal.sbp.domain.model.AccountType
+import dev.pandesal.sbp.domain.model.LenderType
 import java.math.BigDecimal
 
 @Entity(tableName = "accounts")
@@ -15,6 +16,8 @@ data class AccountEntity(
     val currency: String = "PHP",
     val contractValue: BigDecimal? = null,
     val monthlyPayment: BigDecimal? = null,
+    val creditLimit: BigDecimal? = null,
+    val lenderType: String? = null,
     val startDate: String? = null,
     val endDate: String? = null,
 )
@@ -28,6 +31,8 @@ fun AccountEntity.toDomainModel(): Account {
         currency = currency,
         contractValue = contractValue,
         monthlyPayment = monthlyPayment,
+        creditLimit = creditLimit,
+        lenderType = lenderType?.let { LenderType.valueOf(it) },
         startDate = startDate,
         endDate = endDate,
     )
@@ -42,6 +47,8 @@ fun Account.toEntity(): AccountEntity {
         currency = currency,
         contractValue = contractValue,
         monthlyPayment = monthlyPayment,
+        creditLimit = creditLimit,
+        lenderType = lenderType?.name,
         startDate = startDate,
         endDate = endDate,
     )

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -29,7 +29,7 @@ import java.math.BigDecimal
         AccountEntity::class,
         GoalEntity::class,
         RecurringTransactionEntity::class],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(BigDecimalConverter::class, ListStringConverter::class)

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Account.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Account.kt
@@ -19,6 +19,9 @@ data class Account(
     val contractValue: BigDecimal? = null,
     @Serializable(with = BigDecimalSerializer::class)
     val monthlyPayment: BigDecimal? = null,
+    @Serializable(with = BigDecimalSerializer::class)
+    val creditLimit: BigDecimal? = null,
+    val lenderType: LenderType? = null,
     val startDate: String? = null,
     val endDate: String? = null,
 ) : Parcelable
@@ -30,5 +33,14 @@ enum class AccountType : Parcelable {
     MOBILE_DIGITAL_WALLET,
     BANK_ACCOUNT,
     CREDIT_CARD,
-    LOAN,
+    LOAN_FOR_ASSET,
+    LOAN_FOR_SPENDING,
 }
+
+@Serializable
+@Parcelize
+enum class LenderType : Parcelable {
+    INSTITUTION,
+    PERSON,
+}
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -267,5 +267,5 @@ private fun getAccountIcon(type: AccountType): ImageVector = when (type) {
     AccountType.MOBILE_DIGITAL_WALLET -> Icons.Outlined.AccountBalanceWallet
     AccountType.BANK_ACCOUNT -> Icons.Outlined.AccountBalance
     AccountType.CREDIT_CARD -> Icons.Outlined.CreditCard
-    AccountType.LOAN -> Icons.Outlined.AttachMoney
+    AccountType.LOAN_FOR_ASSET, AccountType.LOAN_FOR_SPENDING -> Icons.Outlined.AttachMoney
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/NewAccountScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.pandesal.sbp.domain.model.AccountType
+import dev.pandesal.sbp.domain.model.LenderType
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.extensions.label
 
@@ -63,8 +64,8 @@ fun NewAccountScreen(
     val navigationManager = LocalNavigationManager.current
 
     NewAccountScreen(
-        onSubmit = { name, type, balance, currency, contractValue, monthlyPayment ->
-            viewModel.addAccount(name, type, balance, currency, contractValue, monthlyPayment)
+        onSubmit = { name, type, balance, currency, contractValue, monthlyPayment, creditLimit, lenderType ->
+            viewModel.addAccount(name, type, balance, currency, contractValue, monthlyPayment, creditLimit, lenderType)
         },
         onCancel = { },
         onDismissRequest = {
@@ -79,14 +80,23 @@ private fun getAccountIcon(type: AccountType): ImageVector = when (type) {
     AccountType.MOBILE_DIGITAL_WALLET -> Icons.Outlined.AccountBalanceWallet
     AccountType.BANK_ACCOUNT -> Icons.Outlined.AccountBalance
     AccountType.CREDIT_CARD -> Icons.Outlined.CreditCard
-    AccountType.LOAN -> Icons.Outlined.AttachMoney
+    AccountType.LOAN_FOR_ASSET, AccountType.LOAN_FOR_SPENDING -> Icons.Outlined.AttachMoney
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 private fun NewAccountScreen(
     sheetState: SheetState = rememberModalBottomSheetState(),
-    onSubmit: (name: String, type: AccountType, balance: BigDecimal, currency: String, contractValue: String?, monthlyPayment: String?) -> Unit,
+    onSubmit: (
+        name: String,
+        type: AccountType,
+        balance: BigDecimal,
+        currency: String,
+        contractValue: String?,
+        monthlyPayment: String?,
+        creditLimit: String?,
+        lenderType: LenderType?
+    ) -> Unit,
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
@@ -95,9 +105,12 @@ private fun NewAccountScreen(
     var currency by remember { mutableStateOf("PHP") }
     var contractValue by remember { mutableStateOf("") }
     var monthlyPayment by remember { mutableStateOf("") }
+    var creditLimit by remember { mutableStateOf("") }
+    var lenderType by remember { mutableStateOf<LenderType?>(null) }
     var balance by remember { mutableStateOf(BigDecimal.ZERO) }
     var showCurrencySheet by remember { mutableStateOf(false) }
     var showTypeSheet by remember { mutableStateOf(false) }
+    var showLenderSheet by remember { mutableStateOf(false) }
     var paidAmount by remember { mutableStateOf(true) }
 
     Column(
@@ -150,8 +163,8 @@ private fun NewAccountScreen(
                 }
 
                 val balanceLabel = when {
-                    selectedType == AccountType.LOAN && paidAmount -> "Paid Amount"
-                    selectedType == AccountType.LOAN && !paidAmount -> "Remaining Balance"
+                    (selectedType == AccountType.LOAN_FOR_ASSET || selectedType == AccountType.LOAN_FOR_SPENDING) && paidAmount -> "Paid Amount"
+                    (selectedType == AccountType.LOAN_FOR_ASSET || selectedType == AccountType.LOAN_FOR_SPENDING) && !paidAmount -> "Remaining Balance"
                     else -> "Initial Balance"
                 }
                 Column(modifier = Modifier.padding(top = 16.dp)) {
@@ -202,7 +215,7 @@ private fun NewAccountScreen(
                     }
                 }
 
-                if (selectedType == AccountType.LOAN) {
+                if (selectedType == AccountType.LOAN_FOR_ASSET || selectedType == AccountType.LOAN_FOR_SPENDING) {
                     Column(modifier = Modifier.padding(top = 16.dp)) {
                         Text("Total Contract Value", style = MaterialTheme.typography.bodyMedium)
                         ElevatedCard(
@@ -240,7 +253,7 @@ private fun NewAccountScreen(
                     }
                 }
 
-                if (selectedType == AccountType.LOAN) {
+                if (selectedType == AccountType.LOAN_FOR_ASSET || selectedType == AccountType.LOAN_FOR_SPENDING) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.padding(top = 16.dp)
@@ -252,6 +265,56 @@ private fun NewAccountScreen(
                             modifier = Modifier.padding(horizontal = 8.dp)
                         )
                         Text("Remaining Balance")
+                    }
+
+                    Column(modifier = Modifier.padding(top = 16.dp)) {
+                        Text("Lender Type", style = MaterialTheme.typography.bodyMedium)
+                        ElevatedCard(
+                            modifier = Modifier
+                                .padding(top = 4.dp)
+                                .fillMaxWidth()
+                                .clickable { showLenderSheet = true }
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(
+                                    lenderType?.name?.replace('_', ' ')
+                                        ?.lowercase()
+                                        ?.replaceFirstChar { it.uppercaseChar() }
+                                        ?: "Select",
+                                    modifier = Modifier.padding(16.dp),
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                                Icon(
+                                    Icons.TwoTone.ArrowDropDown,
+                                    contentDescription = null,
+                                    modifier = Modifier.padding(end = 8.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (selectedType == AccountType.CREDIT_CARD) {
+                    Column(modifier = Modifier.padding(top = 16.dp)) {
+                        Text("Credit Limit", style = MaterialTheme.typography.bodyMedium)
+                        ElevatedCard(
+                            modifier = Modifier
+                                .padding(top = 4.dp)
+                                .fillMaxWidth()
+                        ) {
+                            BasicTextField(
+                                value = creditLimit,
+                                onValueChange = { creditLimit = it },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -304,6 +367,26 @@ private fun NewAccountScreen(
             }
         }
 
+        if (showLenderSheet) {
+            val lenderSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            ModalBottomSheet(
+                onDismissRequest = { showLenderSheet = false },
+                sheetState = lenderSheetState
+            ) {
+                LazyColumn(modifier = Modifier.padding(16.dp)) {
+                    items(LenderType.values()) { type ->
+                        ListItem(
+                            headlineContent = { Text(type.name.lowercase().replaceFirstChar { it.uppercaseChar() }) },
+                            modifier = Modifier.clickable {
+                                lenderType = type
+                                showLenderSheet = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(16.dp))
 
         HorizontalFloatingToolbar(
@@ -318,7 +401,9 @@ private fun NewAccountScreen(
                             balance,
                             currency,
                             contractValue.ifBlank { null },
-                            monthlyPayment.ifBlank { null }
+                            monthlyPayment.ifBlank { null },
+                            creditLimit.ifBlank { null },
+                            lenderType
                         )
                         onDismissRequest()
                     }

--- a/app/src/test/java/dev/pandesal/sbp/AccountsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/AccountsViewModelTest.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp
 
 import dev.pandesal.sbp.domain.model.Account
 import dev.pandesal.sbp.domain.model.AccountType
+import dev.pandesal.sbp.domain.model.LenderType
 import dev.pandesal.sbp.domain.usecase.AccountUseCase
 import dev.pandesal.sbp.domain.usecase.CategoryUseCase
 import java.math.BigDecimal
@@ -42,7 +43,16 @@ class AccountsViewModelTest {
     @Test
     fun addAccountInsertsAccount() = runTest {
         val vm = AccountsViewModel(useCase, categoryUseCase)
-        vm.addAccount("B", AccountType.BANK_ACCOUNT, initialBalance = BigDecimal.TEN, "PHP", null, null)
+        vm.addAccount(
+            "B",
+            AccountType.BANK_ACCOUNT,
+            initialBalance = BigDecimal.TEN,
+            "PHP",
+            null,
+            null,
+            null,
+            null
+        )
         advanceUntilIdle()
         assertEquals(1, repository.insertedAccounts.size)
         assertEquals("B", repository.insertedAccounts[0].name)
@@ -52,9 +62,19 @@ class AccountsViewModelTest {
     @Test
     fun addLoanAccountCreatesLiabilityCategory() = runTest {
         val vm = AccountsViewModel(useCase, categoryUseCase)
-        vm.addAccount("Car Loan", AccountType.LOAN, BigDecimal.ZERO, "PHP", "1000", "100")
+        vm.addAccount(
+            "Car Loan",
+            AccountType.LOAN_FOR_ASSET,
+            BigDecimal.ZERO,
+            "PHP",
+            "1000",
+            "100",
+            null,
+            LenderType.INSTITUTION
+        )
         advanceUntilIdle()
         assertEquals("Liabilities", categoryRepository.insertedGroups[0].name)
         assertEquals("Car Loan", categoryRepository.insertedCategories[0].name)
     }
 }
+

--- a/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/extensions/AccountTypeExtensionsTest.kt
@@ -11,6 +11,8 @@ class AccountTypeExtensionsTest {
         assertEquals("Mobile digital wallet", AccountType.MOBILE_DIGITAL_WALLET.label())
         assertEquals("Bank account", AccountType.BANK_ACCOUNT.label())
         assertEquals("Credit card", AccountType.CREDIT_CARD.label())
-        assertEquals("Loan", AccountType.LOAN.label())
+        assertEquals("Loan for asset", AccountType.LOAN_FOR_ASSET.label())
+        assertEquals("Loan for spending", AccountType.LOAN_FOR_SPENDING.label())
     }
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=28
+versionMinor=29
 versionPatch=0


### PR DESCRIPTION
## Summary
- expand account model with lender type and credit limit
- split loans into `LOAN_FOR_ASSET` and `LOAN_FOR_SPENDING`
- track lender type when creating loan accounts
- allow credit limit entry for credit card accounts
- bump database and application versions

## Testing
- `./gradlew test` *(fails: Downloading https://services.gradle.org/distributions/gradle-8.13-bin.zip)*