### PR TITLE
fix: set category name for new goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.30.1] - 2025-05-20
+### Fixed
+- Goals created from Set Budget now use the category name.
 ## [0.29.0] - 2025-05-19
 ### Added
 - Navigate to Recurring Transactions from Settings.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import dev.pandesal.sbp.presentation.categories.CategoriesViewModel
+import dev.pandesal.sbp.presentation.categories.CategoriesUiState
 import dev.pandesal.sbp.presentation.goals.GoalsViewModel
 import java.math.BigDecimal
 import java.time.Instant
@@ -66,8 +67,12 @@ fun SetBudgetScreen(
         initialAmount = initialAmount,
         onSubmit = { amount, isGoal, date ->
             if (isGoal) {
+                val name = (categoriesViewModel.uiState.value as? CategoriesUiState.Success)
+                    ?.categoriesWithBudget
+                    ?.firstOrNull { it.category.id == categoryId }
+                    ?.category?.name ?: ""
                 goalsViewModel.addGoal(
-                    name = "",
+                    name = name,
                     target = amount,
                     dueDate = date,
                     categoryId = categoryId

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=30
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- fix SetBudget goal creation by using the category name
- bump version to 0.30.1
- document change in changelog

## Testing
- `bash ./gradlew test` *(fails: SDK location not found)*