### PR TITLE
Implement account balance updates on transaction insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.31.0] - 2025-05-20
+### Added
+- Transactions now update account balances when inserted.
+- Accounts can be retrieved and updated individually via the repository.
 ## [0.29.0] - 2025-05-19
 ### Added
 - Navigate to Recurring Transactions from Settings.

--- a/app/src/main/java/dev/pandesal/sbp/data/dao/AccountDao.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/dao/AccountDao.kt
@@ -12,8 +12,14 @@ interface AccountDao {
     @Query("SELECT * FROM accounts")
     fun getAccounts(): Flow<List<AccountEntity>>
 
+    @Query("SELECT * FROM accounts WHERE id = :id")
+    suspend fun getAccountById(id: Int): AccountEntity?
+
     @Upsert
     suspend fun insert(value: AccountEntity)
+
+    @Upsert
+    suspend fun update(value: AccountEntity)
 
     @Delete
     suspend fun delete(value: AccountEntity)

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/AccountRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/AccountRepository.kt
@@ -16,8 +16,14 @@ class AccountRepository @Inject constructor(
     override fun getAccounts(): Flow<List<Account>> =
         dao.getAccounts().map { entities -> entities.map { it.toDomainModel() } }
 
+    override suspend fun getAccountById(id: Int): Account? =
+        dao.getAccountById(id)?.toDomainModel()
+
     override suspend fun insertAccount(account: Account) =
         dao.insert(account.toEntity())
+
+    override suspend fun updateAccount(account: Account) =
+        dao.update(account.toEntity())
 
     override suspend fun deleteAccount(account: Account) =
         dao.delete(account.toEntity())

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -80,9 +80,10 @@ object DataModule {
     @Provides
     fun provideTransactionRepository(
         transactionDao: TransactionDao,
-        categoryDao: CategoryDao
+        categoryDao: CategoryDao,
+        accountDao: AccountDao
     ): TransactionRepositoryInterface {
-        return TransactionRepository(transactionDao, categoryDao)
+        return TransactionRepository(transactionDao, categoryDao, accountDao)
     }
 
     @Singleton

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/AccountRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/AccountRepositoryInterface.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface AccountRepositoryInterface {
     fun getAccounts(): Flow<List<Account>>
+    suspend fun getAccountById(id: Int): Account?
     suspend fun insertAccount(account: Account)
+    suspend fun updateAccount(account: Account)
     suspend fun deleteAccount(account: Account)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/AccountUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/AccountUseCase.kt
@@ -10,7 +10,11 @@ class AccountUseCase @Inject constructor(
 ) {
     fun getAccounts(): Flow<List<Account>> = repository.getAccounts()
 
+    suspend fun getAccountById(id: Int): Account? = repository.getAccountById(id)
+
     suspend fun insertAccount(account: Account) = repository.insertAccount(account)
+
+    suspend fun updateAccount(account: Account) = repository.updateAccount(account)
 
     suspend fun deleteAccount(account: Account) = repository.deleteAccount(account)
 }

--- a/app/src/test/java/dev/pandesal/sbp/TransactionRepositoryTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/TransactionRepositoryTest.kt
@@ -1,0 +1,98 @@
+package dev.pandesal.sbp
+
+import dev.pandesal.sbp.data.dao.CategoryDao
+import dev.pandesal.sbp.data.dao.TransactionDao
+import dev.pandesal.sbp.data.local.AccountEntity
+import dev.pandesal.sbp.data.local.toDomainModel
+import dev.pandesal.sbp.data.repository.TransactionRepository
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.fakes.dao.FakeAccountDao
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.time.LocalDate
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TransactionRepositoryTest {
+    private val transactionDao = mockk<TransactionDao>(relaxed = true)
+    private val categoryDao = mockk<CategoryDao>(relaxed = true)
+    private lateinit var accountDao: FakeAccountDao
+    private lateinit var repository: TransactionRepository
+
+    @Before
+    fun setup() {
+        accountDao = FakeAccountDao()
+        repository = TransactionRepository(transactionDao, categoryDao, accountDao)
+    }
+
+    @Test
+    fun insertOutflow_debitsFromAccount() = runTest {
+        val account = AccountEntity(id = 1, name = "A", type = "CASH_WALLET", balance = BigDecimal(100))
+        accountDao.insert(account)
+
+        val tx = Transaction(
+            name = "Coffee",
+            amount = BigDecimal.TEN,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            from = 1,
+            transactionType = TransactionType.OUTFLOW
+        )
+
+        repository.insert(tx)
+
+        val updated = accountDao.getAccountById(1)!!.toDomainModel()
+        assertEquals(BigDecimal(90), updated.balance)
+    }
+
+    @Test
+    fun insertInflow_creditsToAccount() = runTest {
+        val account = AccountEntity(id = 1, name = "A", type = "CASH_WALLET", balance = BigDecimal(50))
+        accountDao.insert(account)
+
+        val tx = Transaction(
+            name = "Salary",
+            amount = BigDecimal.TEN,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            to = 1,
+            transactionType = TransactionType.INFLOW
+        )
+
+        repository.insert(tx)
+
+        val updated = accountDao.getAccountById(1)!!.toDomainModel()
+        assertEquals(BigDecimal(60), updated.balance)
+    }
+
+    @Test
+    fun insertTransfer_updatesBothAccounts() = runTest {
+        val from = AccountEntity(id = 1, name = "A", type = "CASH_WALLET", balance = BigDecimal(100))
+        val to = AccountEntity(id = 2, name = "B", type = "CASH_WALLET", balance = BigDecimal(20))
+        accountDao.insert(from)
+        accountDao.insert(to)
+
+        val tx = Transaction(
+            name = "Move",
+            amount = BigDecimal.TEN,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            from = 1,
+            to = 2,
+            transactionType = TransactionType.TRANSFER
+        )
+
+        repository.insert(tx)
+
+        val updatedFrom = accountDao.getAccountById(1)!!.toDomainModel()
+        val updatedTo = accountDao.getAccountById(2)!!.toDomainModel()
+        assertEquals(BigDecimal(90), updatedFrom.balance)
+        assertEquals(BigDecimal(30), updatedTo.balance)
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/fakes/FakeAccountRepository.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/FakeAccountRepository.kt
@@ -11,8 +11,17 @@ class FakeAccountRepository : AccountRepositoryInterface {
 
     override fun getAccounts(): Flow<List<Account>> = accountsFlow
 
+    override suspend fun getAccountById(id: Int): Account? =
+        accountsFlow.value.firstOrNull { it.id == id }
+
     override suspend fun insertAccount(account: Account) {
         insertedAccounts.add(account)
+    }
+
+    override suspend fun updateAccount(account: Account) {
+        accountsFlow.value = accountsFlow.value.map {
+            if (it.id == account.id) account else it
+        }
     }
 
     override suspend fun deleteAccount(account: Account) { /* no-op */ }

--- a/app/src/test/java/dev/pandesal/sbp/fakes/dao/FakeAccountDao.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/dao/FakeAccountDao.kt
@@ -1,0 +1,30 @@
+package dev.pandesal.sbp.fakes.dao
+
+import dev.pandesal.sbp.data.dao.AccountDao
+import dev.pandesal.sbp.data.local.AccountEntity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeAccountDao : AccountDao {
+    private val accounts = mutableListOf<AccountEntity>()
+    private val flow = MutableStateFlow<List<AccountEntity>>(accounts)
+
+    override fun getAccounts(): Flow<List<AccountEntity>> = flow.asStateFlow()
+
+    override suspend fun getAccountById(id: Int): AccountEntity? =
+        accounts.find { it.id == id }
+
+    override suspend fun insert(value: AccountEntity) {
+        accounts.removeAll { it.id == value.id }
+        accounts.add(value)
+        flow.value = accounts.toList()
+    }
+
+    override suspend fun update(value: AccountEntity) = insert(value)
+
+    override suspend fun delete(value: AccountEntity) {
+        accounts.removeIf { it.id == value.id }
+        flow.value = accounts.toList()
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=30
+versionMinor=31
 versionPatch=0


### PR DESCRIPTION
## Summary
- extend account DAO and repository to fetch/update single accounts
- modify transaction repository to adjust account balances when inserting
- provide account DAO for transaction repo
- bump version to 0.31.0
- add tests for account balance updates

## Testing
- `./gradlew test` *(fails: SDK location not found)*