### PR TITLE
Add SMS import feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.0] - 2025-05-20
+### Added
+- feat: Experimental SMS import button in Settings.
+
 ## [0.30.1] - 2025-05-20
 ### Fixed
 - Goals created from Set Budget now use the category name.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_SMS" />
+
     <application
         android:name=".presentation.ApplicationClass"
         android:allowBackup="true"

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -24,6 +24,7 @@ import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
 import dev.pandesal.sbp.domain.repository.GoalRepositoryInterface
 import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
 import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import dev.pandesal.sbp.notification.SmsTransactionScanner
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -116,6 +117,12 @@ object DataModule {
     ): RecurringTransactionRepositoryInterface {
         return RecurringTransactionRepository(dao)
     }
+
+    @Singleton
+    @Provides
+    fun provideSmsTransactionScanner(
+        @ApplicationContext context: Context
+    ): SmsTransactionScanner = SmsTransactionScanner(context)
 
 
 }

--- a/app/src/main/java/dev/pandesal/sbp/notification/SmsTransactionScanner.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/SmsTransactionScanner.kt
@@ -1,0 +1,41 @@
+package dev.pandesal.sbp.notification
+
+import android.content.Context
+import android.provider.Telephony
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.pandesal.sbp.domain.model.NotificationType
+import javax.inject.Inject
+
+class SmsTransactionScanner @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    fun scan() {
+        val cursor = context.contentResolver.query(
+            Telephony.Sms.Inbox.CONTENT_URI,
+            arrayOf(Telephony.Sms.BODY),
+            null,
+            null,
+            null
+        ) ?: return
+
+        cursor.use {
+            val bodyIndex = it.getColumnIndexOrThrow(Telephony.Sms.BODY)
+            while (it.moveToNext()) {
+                val body = it.getString(bodyIndex) ?: continue
+                if (isFinancialSms(body)) {
+                    InAppNotificationCenter.postNotification(
+                        message = body,
+                        type = NotificationType.TRANSACTION_SUGGESTION,
+                        canCreateTransaction = true
+                    )
+                }
+            }
+        }
+    }
+
+    private fun isFinancialSms(text: String): Boolean {
+        val pattern = Regex("(?i)(\\bpaid\\b|\\bpurchase\\b|\\bdeposit\\b|\\bspent\\b|\\bpayment\\b|₱|PHP)")
+        return pattern.containsMatchIn(text)
+    }
+}
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
@@ -47,7 +47,8 @@ fun SettingsScreen(
         onCurrencyChange = viewModel::setCurrency,
         onRecurringTransactionsClick = {
             nav.navigate(dev.pandesal.sbp.presentation.NavigationDestination.RecurringTransactions)
-        }
+        },
+        onScanSms = viewModel::scanSms
     )
 }
 
@@ -65,7 +66,8 @@ private fun SettingsContent(
     onDarkModeChange: (Boolean) -> Unit,
     onNotificationsChange: (Boolean) -> Unit,
     onCurrencyChange: (String) -> Unit,
-    onRecurringTransactionsClick: () -> Unit
+    onRecurringTransactionsClick: () -> Unit,
+    onScanSms: () -> Unit
 ) {
     var darkMode by remember { mutableStateOf(settings.darkMode) }
     var notificationsEnabled by remember { mutableStateOf(settings.notificationsEnabled) }
@@ -74,11 +76,17 @@ private fun SettingsContent(
         notificationsEnabled = granted
         onNotificationsChange(granted)
     }
+    val smsLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        if (granted) {
+            onScanSms()
+        }
+    }
     val items = listOf(
         SettingItem("Dark mode", SettingType.SWITCH),
         SettingItem("Enable notifications", SettingType.SWITCH),
         SettingItem("Currency", SettingType.TEXT),
-        SettingItem("Recurring Transactions", SettingType.TEXT)
+        SettingItem("Recurring Transactions", SettingType.TEXT),
+        SettingItem("Import SMS Transactions", SettingType.TEXT)
     )
 
     val context = LocalContext.current
@@ -122,6 +130,14 @@ private fun SettingsContent(
                     }
                     "Recurring Transactions" -> SettingText(item.title, "") {
                         onRecurringTransactionsClick()
+                    }
+                    "Import SMS Transactions" -> SettingText(item.title, "") {
+                        val permission = Manifest.permission.READ_SMS
+                        if (ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED) {
+                            onScanSms()
+                        } else {
+                            smsLauncher.launch(permission)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.pandesal.sbp.domain.model.Settings
 import dev.pandesal.sbp.domain.usecase.SettingsUseCase
+import dev.pandesal.sbp.notification.SmsTransactionScanner
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -14,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
-    private val useCase: SettingsUseCase
+    private val useCase: SettingsUseCase,
+    private val smsScanner: SmsTransactionScanner
 ) : ViewModel() {
 
     val settings: StateFlow<Settings> = useCase.getSettings()
@@ -30,5 +32,9 @@ class SettingsViewModel @Inject constructor(
 
     fun setCurrency(currency: String) {
         viewModelScope.launch { useCase.setCurrency(currency) }
+    }
+
+    fun scanSms() {
+        viewModelScope.launch { smsScanner.scan() }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=30
-versionPatch=1
+versionMinor=31
+versionPatch=0


### PR DESCRIPTION
## Summary
- add experimental SMS import option in Settings
- implement `SmsTransactionScanner` service
- provide scanner with Hilt
- bump version to 0.31.0
- document new feature in CHANGELOG

## Testing
- `./gradlew test` *(fails: No route to host)*