### PR TITLE
Add reminders for recurring transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-
+## [0.32.0] - 2025-05-20
+### Added
+- feat: Toggle reminders for recurring transactions.
 ## [0.31.1] - 2025-05-20
 ### Fixed
 - fix: correct unallocated funds calculation.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
         <service
             android:name=".notification.FinancialAppUsageService"
             android:exported="false" />
+        <service
+            android:name=".notification.RecurringReminderService"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/dev/pandesal/sbp/data/local/RecurringTransaction.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/RecurringTransaction.kt
@@ -35,6 +35,7 @@ data class RecurringTransactionEntity(
     val interval: String,
     val cutoffDays: Int = 21,
     val startDate: String,
+    val reminderEnabled: Boolean = false,
 )
 
 fun RecurringTransactionEntity.toDomainModel(): RecurringTransaction {
@@ -63,7 +64,8 @@ fun RecurringTransactionEntity.toDomainModel(): RecurringTransaction {
         transaction = transaction,
         interval = RecurringInterval.valueOf(interval),
         cutoffDays = cutoffDays,
-        startDate = LocalDate.parse(startDate)
+        startDate = LocalDate.parse(startDate),
+        reminderEnabled = reminderEnabled
     )
 }
 
@@ -89,5 +91,6 @@ fun RecurringTransaction.toEntity(): RecurringTransactionEntity {
         interval = interval.name,
         cutoffDays = cutoffDays,
         startDate = startDate.toString(),
+        reminderEnabled = reminderEnabled,
     )
 }

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -29,7 +29,7 @@ import java.math.BigDecimal
         AccountEntity::class,
         GoalEntity::class,
         RecurringTransactionEntity::class],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 @TypeConverters(BigDecimalConverter::class, ListStringConverter::class)

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/RecurringTransaction.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/RecurringTransaction.kt
@@ -20,5 +20,6 @@ data class RecurringTransaction(
     val transaction: Transaction,
     val interval: RecurringInterval,
     val cutoffDays: Int = 21,
-    val startDate: LocalDate = LocalDate.now()
+    val startDate: LocalDate = LocalDate.now(),
+    val reminderEnabled: Boolean = false
 ) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
@@ -26,7 +26,7 @@ class RecurringTransactionUseCase @Inject constructor(
     ): Flow<List<Notification>> {
         val endDate = currentDate.plusDays(withinDays)
         return repository.getRecurringTransactions().map { list ->
-            list.mapNotNull { rec ->
+            list.filter { it.reminderEnabled }.mapNotNull { rec ->
                 val next = nextDueDate(rec, currentDate)
                 if (!next.isAfter(endDate)) {
                     Notification(

--- a/app/src/main/java/dev/pandesal/sbp/notification/RecurringReminderService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/RecurringReminderService.kt
@@ -1,0 +1,56 @@
+package dev.pandesal.sbp.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import dagger.hilt.android.AndroidEntryPoint
+import dev.pandesal.sbp.R
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.first
+import java.time.LocalDate
+
+@AndroidEntryPoint
+class RecurringReminderService : Service() {
+
+    @Inject lateinit var useCase: RecurringTransactionUseCase
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        CoroutineScope(Dispatchers.IO).launch {
+            val notifications = useCase.getUpcomingNotifications(LocalDate.now(), 1).first()
+            notifications.forEach { push(it.message) }
+            stopSelf(startId)
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun push(message: String) {
+        val channelId = "recurring_reminders"
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                channelId,
+                "Recurring Reminders",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            manager.createNotificationChannel(channel)
+        }
+        val notify = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Upcoming Bill")
+            .setContentText(message)
+            .setAutoCancel(true)
+            .build()
+        manager.notify(message.hashCode(), notify)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -118,8 +118,8 @@ fun NewTransactionScreen(
             editable = editable,
             onEdit = { editable = true },
             onDelete = { showDelete = true },
-            onSave = { _, recur, interval, cutoff ->
-                viewModel.saveTransaction(recur, interval, cutoff) {
+            onSave = { _, recur, interval, cutoff, reminder ->
+                viewModel.saveTransaction(recur, interval, cutoff, reminder) {
                     navManager.navigateUp()
                 }
             },
@@ -165,7 +165,7 @@ private fun NewTransactionScreen(
     editable: Boolean,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
-    onSave: (Transaction, Boolean, RecurringInterval, Int) -> Unit,
+    onSave: (Transaction, Boolean, RecurringInterval, Int, Boolean) -> Unit,
     onCancel: () -> Unit,
     onUpdate: (Transaction) -> Unit
 ) {
@@ -213,6 +213,7 @@ private fun NewTransactionScreen(
     var recurringExpanded by remember { mutableStateOf(false) }
     var selectedInterval by remember { mutableStateOf(RecurringInterval.MONTHLY) }
     var cutoffDays by remember { mutableIntStateOf(21) }
+    var reminderEnabled by remember { mutableStateOf(false) }
 
     // Transaction Type Tabs
     val transactionTypes =
@@ -751,6 +752,24 @@ private fun NewTransactionScreen(
                                             .fillMaxWidth()
                                     )
                                 }
+
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Switch(
+                                        enabled = editable,
+                                        checked = reminderEnabled,
+                                        onCheckedChange = { reminderEnabled = it }
+                                    )
+                                    Text(
+                                        text = "Reminders",
+                                        modifier = Modifier.padding(start = 8.dp),
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                }
                             }
                         }
                     }
@@ -769,7 +788,7 @@ private fun NewTransactionScreen(
                     floatingActionButton = {
                         FloatingToolbarDefaults.VibrantFloatingActionButton(
                             onClick = {
-                                onSave(transaction, isRecurring, selectedInterval, cutoffDays)
+                                onSave(transaction, isRecurring, selectedInterval, cutoffDays, reminderEnabled)
                             },
                         ) {
                             Icon(Icons.Default.Check, "Localized description")

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -148,6 +148,7 @@ class NewTransactionsViewModel @Inject constructor(
         isRecurring: Boolean,
         interval: RecurringInterval,
         cutoffDays: Int,
+        reminderEnabled: Boolean,
         onResult: (Boolean) -> Unit = {}
     ) {
         viewModelScope.launch {
@@ -168,7 +169,8 @@ class NewTransactionsViewModel @Inject constructor(
                     val recurring = dev.pandesal.sbp.domain.model.RecurringTransaction(
                         transaction = _transaction.value,
                         interval = interval,
-                        cutoffDays = cutoffDays
+                        cutoffDays = cutoffDays,
+                        reminderEnabled = reminderEnabled
                     )
                     recurringTransactionUseCase.addRecurringTransaction(recurring)
                 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/recurringdetails/RecurringTransactionDetailsScreen.kt
@@ -111,6 +111,24 @@ fun RecurringTransactionDetailsScreen(
                     enabled = false,
                     label = { Text("Start Date") }
                 )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Switch(
+                        checked = rec.reminderEnabled,
+                        onCheckedChange = {
+                            viewModel.update(rec.copy(reminderEnabled = it))
+                        },
+                        enabled = editable
+                    )
+                    Text(
+                        text = "Reminders",
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
+                }
             }
         }
 

--- a/app/src/test/java/dev/pandesal/sbp/NewTransactionsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/NewTransactionsViewModelTest.kt
@@ -62,7 +62,7 @@ class NewTransactionsViewModelTest {
         vm.updateTransaction(
             Transaction(name = "Test", category = Category(id = 1, name = "C", description = "", icon = "", categoryGroupId = 1, categoryType = TransactionType.OUTFLOW, weight = 0), from = 1, fromAccountName = "1", amount = "100.00".toBigDecimal(), createdAt = LocalDate.now(), updatedAt = LocalDate.now(), transactionType = TransactionType.OUTFLOW)
         )
-        vm.saveTransaction(false, interval = RecurringInterval.MONTHLY, cutoffDays = 1)
+        vm.saveTransaction(false, interval = RecurringInterval.MONTHLY, cutoffDays = 1, reminderEnabled = true)
         advanceUntilIdle()
         assertEquals(1, transactionRepo.insertedTransactions.size)
     }
@@ -86,7 +86,7 @@ class NewTransactionsViewModelTest {
             )
         )
 
-        vm.saveTransaction(false, RecurringInterval.MONTHLY, 1)
+        vm.saveTransaction(false, RecurringInterval.MONTHLY, 1, true)
         advanceUntilIdle()
         assertEquals(account.balance - BigDecimal.TEN, accountRepo.insertedAccounts.last().balance)
     }

--- a/app/src/test/java/dev/pandesal/sbp/RecurringTransactionDetailsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/RecurringTransactionDetailsViewModelTest.kt
@@ -35,7 +35,8 @@ class RecurringTransactionDetailsViewModelTest {
                 transactionType = TransactionType.OUTFLOW
             ),
             interval = RecurringInterval.MONTHLY,
-            startDate = LocalDate.now()
+            startDate = LocalDate.now(),
+            reminderEnabled = true
         )
         repository.transactionsFlow.value = listOf(tx)
 
@@ -56,7 +57,8 @@ class RecurringTransactionDetailsViewModelTest {
                 transactionType = TransactionType.OUTFLOW
             ),
             interval = RecurringInterval.MONTHLY,
-            startDate = LocalDate.now()
+            startDate = LocalDate.now(),
+            reminderEnabled = true
         )
         repository.transactionsFlow.value = listOf(tx)
         val vm = RecurringTransactionDetailsViewModel(useCase)

--- a/app/src/test/java/dev/pandesal/sbp/RecurringTransactionsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/RecurringTransactionsViewModelTest.kt
@@ -35,7 +35,13 @@ class RecurringTransactionsViewModelTest {
             updatedAt = LocalDate.now(),
             transactionType = TransactionType.OUTFLOW
         )
-        repository.transactionsFlow.value = listOf(RecurringTransaction(tx, dev.pandesal.sbp.domain.model.RecurringInterval.MONTHLY))
+        repository.transactionsFlow.value = listOf(
+            RecurringTransaction(
+                transaction = tx,
+                interval = dev.pandesal.sbp.domain.model.RecurringInterval.MONTHLY,
+                reminderEnabled = true
+            )
+        )
         val vm = RecurringTransactionsViewModel(useCase)
         advanceUntilIdle()
         val state = vm.uiState.value as RecurringTransactionsUiState.Success

--- a/app/src/test/java/dev/pandesal/sbp/local/MappingTests.kt
+++ b/app/src/test/java/dev/pandesal/sbp/local/MappingTests.kt
@@ -90,7 +90,8 @@ class MappingTests {
             ),
             interval = dev.pandesal.sbp.domain.model.RecurringInterval.MONTHLY,
             cutoffDays = 15,
-            startDate = LocalDate.now()
+            startDate = LocalDate.now(),
+            reminderEnabled = true
         )
 
         val entity = domain.toEntity()

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=31
-versionPatch=1
+versionMinor=32
+versionPatch=0


### PR DESCRIPTION
## Summary
- add reminderEnabled toggle to RecurringTransaction model and entity
- filter recurring reminders in use case
- add switch for reminders in new and details screens
- add RecurringReminderService for push notifications
- update database and manifest
- bump version to 0.32.0

## Testing
- `./gradlew test` *(fails: No route to host)*