### PR TITLE
Add finance app usage detection toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-21
+### Added
+- feat: Detect finance app usage with permission toggle.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
@@ -21,6 +21,7 @@ class SettingsRepository @Inject constructor(
     private object Keys {
         val DARK_MODE = booleanPreferencesKey("dark_mode")
         val NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
+        val DETECT_FINANCE_APP_USAGE = booleanPreferencesKey("detect_finance_app_usage")
         val CURRENCY = stringPreferencesKey("currency")
     }
 
@@ -29,6 +30,7 @@ class SettingsRepository @Inject constructor(
             Settings(
                 darkMode = prefs[Keys.DARK_MODE] ?: false,
                 notificationsEnabled = prefs[Keys.NOTIFICATIONS_ENABLED] ?: true,
+                detectFinanceAppUsage = prefs[Keys.DETECT_FINANCE_APP_USAGE] ?: false,
                 currency = prefs[Keys.CURRENCY] ?: "PHP"
             )
         }
@@ -39,6 +41,10 @@ class SettingsRepository @Inject constructor(
 
     override suspend fun setNotificationsEnabled(enabled: Boolean) {
         context.settingsDataStore.edit { it[Keys.NOTIFICATIONS_ENABLED] = enabled }
+    }
+
+    override suspend fun setDetectFinanceAppUsage(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.DETECT_FINANCE_APP_USAGE] = enabled }
     }
 
     override suspend fun setCurrency(currency: String) {

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
@@ -3,5 +3,6 @@ package dev.pandesal.sbp.domain.model
 data class Settings(
     val darkMode: Boolean = false,
     val notificationsEnabled: Boolean = true,
+    val detectFinanceAppUsage: Boolean = false,
     val currency: String = "PHP"
 )

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
@@ -7,5 +7,6 @@ interface SettingsRepositoryInterface {
     fun getSettings(): Flow<Settings>
     suspend fun setDarkMode(enabled: Boolean)
     suspend fun setNotificationsEnabled(enabled: Boolean)
+    suspend fun setDetectFinanceAppUsage(enabled: Boolean)
     suspend fun setCurrency(currency: String)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
@@ -12,5 +12,6 @@ class SettingsUseCase @Inject constructor(
 
     suspend fun setDarkMode(enabled: Boolean) = repository.setDarkMode(enabled)
     suspend fun setNotificationsEnabled(enabled: Boolean) = repository.setNotificationsEnabled(enabled)
+    suspend fun setDetectFinanceAppUsage(enabled: Boolean) = repository.setDetectFinanceAppUsage(enabled)
     suspend fun setCurrency(currency: String) = repository.setCurrency(currency)
 }

--- a/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/FinancialAppUsageService.kt
@@ -52,7 +52,10 @@ class FinancialAppUsageService : Service() {
         private const val CHECK_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
         val FINANCIAL_KEYWORDS = listOf(
             "bpi", "bdo", "metrobank", "securitybank", "maybank",
-            "eastwest", "rcbc", "unionbank", "gcash", "maya"
+            "eastwest", "rcbc", "unionbank", "gcash", "maya",
+            "pnb", "landbank", "chinabank", "psbank", "coins",
+            "tonik", "ing", "seabank", "gotyme", "diskartech",
+            "komo", "grabpay"
         )
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
@@ -2,10 +2,14 @@ package dev.pandesal.sbp.presentation.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import android.content.Context
+import android.content.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.pandesal.sbp.domain.model.Settings
 import dev.pandesal.sbp.domain.usecase.SettingsUseCase
 import dev.pandesal.sbp.notification.SmsTransactionScanner
+import dev.pandesal.sbp.notification.FinancialAppUsageService
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -16,7 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val useCase: SettingsUseCase,
-    private val smsScanner: SmsTransactionScanner
+    private val smsScanner: SmsTransactionScanner,
+    @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     val settings: StateFlow<Settings> = useCase.getSettings()
@@ -28,6 +33,14 @@ class SettingsViewModel @Inject constructor(
 
     fun setNotificationsEnabled(enabled: Boolean) {
         viewModelScope.launch { useCase.setNotificationsEnabled(enabled) }
+    }
+
+    fun setDetectFinanceAppUsage(enabled: Boolean) {
+        viewModelScope.launch { useCase.setDetectFinanceAppUsage(enabled) }
+    }
+
+    fun detectFinanceApps() {
+        context.startService(Intent(context, FinancialAppUsageService::class.java))
     }
 
     fun setCurrency(currency: String) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## Summary
- add Detect Finance App Usage switch in Settings
- persist detectFinanceAppUsage in Settings repository and model
- enable detection via FinancialAppUsageService when permission is granted
- expand financial app keyword list
- bump version to 0.34.0

## Testing
- `./gradlew test` *(fails: No route to host)*