### PR TITLE
Fix scroll priority for Home transactions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.
 
+## [0.33.1] - 2025-05-20
+### Fixed
+- fix: give priority to transaction list scrolling when sheet is expanded.
+
 ## [0.32.0] - 2025-05-20
 ### Added
 - feat: Toggle reminders for recurring transactions.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -172,6 +172,7 @@ private fun HomeScreenContent(
     BottomSheetScaffold(
         containerColor = Color.Transparent,
         scaffoldState = scaffoldState,
+        sheetSwipeEnabled = scaffoldState.bottomSheetState.currentValue != SheetValue.Expanded,
         sheetPeekHeight = with(density) {
             val heightWithPadding = sheetHeightPx.floatValue.toDp() - navigationBarHeight - 24.dp
             if (heightWithPadding > 0.dp) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=33
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- disable sheet swipe when bottom sheet is expanded so the list scrolls normally
- update CHANGELOG
- bump version to 0.33.1

## Testing
- `./gradlew lint` *(fails: No route to host)*