### PR TITLE
Add receipt OCR support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-20
+### Added
+- feat: Attach receipt photos and OCR details for quick entry.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.lottie.compose)
     implementation(libs.reorderable)
+    implementation(libs.mlkit.text.recognition)
 
     implementation(libs.generativeai)
     implementation(libs.kotlinx.serialization.json)

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -129,5 +129,19 @@ object DataModule {
         @ApplicationContext context: Context
     ): SmsTransactionScanner = SmsTransactionScanner(context)
 
+    @Singleton
+    @Provides
+    fun provideReceiptOcrService(
+        @ApplicationContext context: Context
+    ): dev.pandesal.sbp.domain.service.ReceiptOcrService =
+        dev.pandesal.sbp.domain.service.ReceiptOcrService(context)
+
+    @Singleton
+    @Provides
+    fun provideReceiptUseCase(
+        service: dev.pandesal.sbp.domain.service.ReceiptOcrService
+    ): dev.pandesal.sbp.domain.usecase.ReceiptUseCase =
+        dev.pandesal.sbp.domain.usecase.ReceiptUseCase(service)
+
 
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/ReceiptData.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/ReceiptData.kt
@@ -1,0 +1,10 @@
+package dev.pandesal.sbp.domain.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+data class ReceiptData(
+    val merchantName: String? = null,
+    val amount: BigDecimal? = null,
+    val date: LocalDate? = null
+)

--- a/app/src/main/java/dev/pandesal/sbp/domain/service/ReceiptOcrService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/service/ReceiptOcrService.kt
@@ -1,0 +1,35 @@
+package dev.pandesal.sbp.domain.service
+
+import android.content.Context
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.pandesal.sbp.domain.model.ReceiptData
+import java.math.BigDecimal
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+@Singleton
+class ReceiptOcrService @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
+    suspend fun parseReceipt(image: InputImage): ReceiptData =
+        suspendCancellableCoroutine { cont ->
+            recognizer.process(image)
+                .addOnSuccessListener { visionText ->
+                    val text = visionText.text
+                    val amountRegex = Regex("(\\d+[.,]\\d{2})")
+                    val amount = amountRegex.find(text)?.value?.replace(",", "")?.toBigDecimalOrNull()
+                    val dateRegex = Regex("(\\d{4}-\\d{2}-\\d{2})")
+                    val date = dateRegex.find(text)?.value?.let { LocalDate.parse(it) }
+                    val merchant = text.lines().firstOrNull()
+                    cont.resume(ReceiptData(merchant, amount, date)) {}
+                }
+                .addOnFailureListener { cont.resume(ReceiptData()) {} }
+        }
+}

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/ReceiptUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/ReceiptUseCase.kt
@@ -1,0 +1,12 @@
+package dev.pandesal.sbp.domain.usecase
+
+import com.google.mlkit.vision.common.InputImage
+import dev.pandesal.sbp.domain.model.ReceiptData
+import dev.pandesal.sbp.domain.service.ReceiptOcrService
+import javax.inject.Inject
+
+class ReceiptUseCase @Inject constructor(
+    private val service: ReceiptOcrService
+) {
+    suspend fun parse(image: InputImage): ReceiptData = service.parseReceipt(image)
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -1,6 +1,5 @@
 package dev.pandesal.sbp.presentation.transactions.newtransaction
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -10,6 +9,7 @@ import dev.pandesal.sbp.domain.model.Account
 import dev.pandesal.sbp.domain.model.MonthlyBudget
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.usecase.ReceiptUseCase
 import dev.pandesal.sbp.domain.usecase.CategoryUseCase
 import dev.pandesal.sbp.domain.usecase.AccountUseCase
 import dev.pandesal.sbp.domain.usecase.TransactionUseCase
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import com.google.mlkit.vision.common.InputImage
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.YearMonth
@@ -35,7 +36,8 @@ class NewTransactionsViewModel @Inject constructor(
     private val transactionUseCase: TransactionUseCase,
     private val categoryUseCase: CategoryUseCase,
     private val accountUseCase: AccountUseCase,
-    private val recurringTransactionUseCase: RecurringTransactionUseCase
+    private val recurringTransactionUseCase: RecurringTransactionUseCase,
+    private val receiptUseCase: ReceiptUseCase
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<NewTransactionUiState>(NewTransactionUiState.Initial)
@@ -95,6 +97,20 @@ class NewTransactionsViewModel @Inject constructor(
                         _uiState.value = current.copy(merchants = merchants)
                     }
                 }
+        }
+    }
+
+    fun attachReceipt(uri: android.net.Uri, context: android.content.Context) {
+        viewModelScope.launch {
+            val image = InputImage.fromFilePath(context, uri)
+            val data = receiptUseCase.parse(image)
+            val updated = _transaction.value.copy(
+                merchantName = data.merchantName ?: _transaction.value.merchantName,
+                amount = data.amount ?: _transaction.value.amount,
+                createdAt = data.date ?: _transaction.value.createdAt,
+                attachment = uri.toString()
+            )
+            updateTransaction(updated)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ googleAndroidLibrariesMapsplatformSecretsGradlePlugin = "2.0.1"
 reorderable = "2.4.3"
 material3 = "1.4.0-alpha14"
 datastore = "1.1.0"
+mlkitText = "16.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -75,6 +76,7 @@ mockito-kotlin = { module = "org.mockito:mockito-kotlin", version.ref = "mockito
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkitText" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add ReceiptOcrService with ML Kit integration
- support attaching receipts in New Transaction dialog
- parse receipt data via new ReceiptUseCase and update transaction
- bump version to 0.34.0

## Testing
- `./gradlew lint` *(fails: No route to host)*
- `./gradlew test` *(fails: No route to host)*