### PR TITLE
Add spending trend analysis and forecasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-20
+### Added
+- feat: Add spending trends and forecast screen.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/TrendUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/TrendUseCase.kt
@@ -1,0 +1,49 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
+import java.time.YearMonth
+import java.time.temporal.WeekFields
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class TrendUseCase @Inject constructor(
+    private val repository: TransactionRepositoryInterface
+) {
+
+    fun getWeeklySpending(): Flow<List<Pair<String, Double>>> =
+        repository.getAllTransactions().map { txs ->
+            txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                .groupBy { Pair(it.createdAt.year, it.createdAt.get(WeekFields.ISO.weekOfWeekBasedYear())) }
+                .toSortedMap(compareBy({ it.first }, { it.second }))
+                .map { (pair, list) ->
+                    "W${pair.second}" to list.sumOf { it.amount.toDouble() }
+                }
+        }
+
+    fun getMonthlySpending(): Flow<List<Pair<String, Double>>> =
+        repository.getAllTransactions().map { txs ->
+            txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                .groupBy { YearMonth.from(it.createdAt) }
+                .toSortedMap()
+                .map { (month, list) ->
+                    month.toString() to list.sumOf { it.amount.toDouble() }
+                }
+        }
+
+    fun getYearlySpending(): Flow<List<Pair<String, Double>>> =
+        repository.getAllTransactions().map { txs ->
+            txs.filter { it.transactionType == TransactionType.OUTFLOW }
+                .groupBy { it.createdAt.year }
+                .toSortedMap()
+                .map { (year, list) ->
+                    year.toString() to list.sumOf { it.amount.toDouble() }
+                }
+        }
+
+    fun forecastNextMonth(): Flow<Double> =
+        getMonthlySpending().map { months ->
+            if (months.isEmpty()) 0.0 else months.takeLast(3).map { it.second }.average()
+        }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -17,6 +17,7 @@ import dev.pandesal.sbp.presentation.categories.new.NewCategoryGroupScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryScreen
 import dev.pandesal.sbp.presentation.home.HomeScreen
 import dev.pandesal.sbp.presentation.insights.InsightsScreen
+import dev.pandesal.sbp.presentation.trends.TrendsScreen
 import dev.pandesal.sbp.presentation.transactions.TransactionsScreen
 import dev.pandesal.sbp.presentation.transactions.newtransaction.NewTransactionScreen
 import dev.pandesal.sbp.domain.model.Transaction
@@ -40,6 +41,8 @@ sealed class NavigationDestination() {
     data object Categories : NavigationDestination()
     @Serializable
     data object Insights : NavigationDestination()
+    @Serializable
+    data object Trends : NavigationDestination()
     @Serializable
     data object More : NavigationDestination()
     @Serializable
@@ -179,6 +182,10 @@ fun AppNavigation(navController: NavHostController) {
 
             composable<NavigationDestination.Insights> {
                 InsightsScreen()
+            }
+
+            composable<NavigationDestination.Trends> {
+                dev.pandesal.sbp.presentation.trends.TrendsScreen()
             }
 
             composable<NavigationDestination.More> {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PieChart
@@ -198,6 +199,18 @@ class MainActivity : ComponentActivity() {
                                     Icon(
                                         Icons.Filled.BarChart,
                                         contentDescription = "Localized description"
+                                    )
+                                }
+                                IconButton(onClick = {
+                                    navController.navigate(NavigationDestination.Trends) {
+                                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                                        launchSingleTop = true
+                                        restoreState = true
+                                    }
+                                }) {
+                                    Icon(
+                                        Icons.Filled.TrendingUp,
+                                        contentDescription = "Trends"
                                     )
                                 }
                                 IconButton(onClick = {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/TrendUiModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/TrendUiModel.kt
@@ -1,0 +1,7 @@
+package dev.pandesal.sbp.presentation.model
+
+/** Model for spending trends */
+data class TrendUiModel(
+    val label: String,
+    val amount: Double
+)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsScreen.kt
@@ -1,0 +1,51 @@
+package dev.pandesal.sbp.presentation.trends
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.components.TimePeriodDropdown
+import dev.pandesal.sbp.presentation.insights.TimePeriod
+import dev.pandesal.sbp.presentation.trends.components.SpendingTrendLineChart
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun TrendsScreen(viewModel: TrendsViewModel = hiltViewModel()) {
+    val state by viewModel.uiState.collectAsState()
+    val period by viewModel.period.collectAsState()
+
+    if (state is TrendsUiState.Ready) {
+        val data = state as TrendsUiState.Ready
+        val trends = data.trends[period] ?: emptyList()
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Trends", style = MaterialTheme.typography.titleLargeEmphasized)
+            Spacer(modifier = Modifier.height(16.dp))
+            Box {
+                SpendingTrendLineChart(trends)
+                TimePeriodDropdown(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    period = period,
+                    onPeriodChange = { viewModel.setPeriod(it) }
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Next month forecast: ${"%.2f".format(data.forecast)}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Spacer(modifier = Modifier.height(140.dp))
+        }
+    }
+}
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsUiState.kt
@@ -1,0 +1,13 @@
+package dev.pandesal.sbp.presentation.trends
+
+import dev.pandesal.sbp.presentation.insights.TimePeriod
+import dev.pandesal.sbp.presentation.model.TrendUiModel
+
+sealed interface TrendsUiState {
+    data object Loading : TrendsUiState
+    data class Ready(
+        val trends: Map<TimePeriod, List<TrendUiModel>>,
+        val forecast: Double
+    ) : TrendsUiState
+    data class Error(val message: String) : TrendsUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/trends/TrendsViewModel.kt
@@ -1,0 +1,54 @@
+package dev.pandesal.sbp.presentation.trends
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.usecase.TrendUseCase
+import dev.pandesal.sbp.presentation.insights.TimePeriod
+import dev.pandesal.sbp.presentation.model.TrendUiModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class TrendsViewModel @Inject constructor(
+    private val useCase: TrendUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TrendsUiState>(TrendsUiState.Loading)
+    val uiState: StateFlow<TrendsUiState> = _uiState.asStateFlow()
+
+    private val _period = MutableStateFlow(TimePeriod.MONTHLY)
+    val period: StateFlow<TimePeriod> = _period.asStateFlow()
+
+    init {
+        observeData()
+    }
+
+    fun setPeriod(period: TimePeriod) {
+        _period.value = period
+    }
+
+    private fun observeData() {
+        viewModelScope.launch {
+            combine(
+                useCase.getWeeklySpending(),
+                useCase.getMonthlySpending(),
+                useCase.getYearlySpending(),
+                useCase.forecastNextMonth()
+            ) { weekly, monthly, yearly, forecast ->
+                val map = mapOf(
+                    TimePeriod.WEEKLY to weekly.map { TrendUiModel(it.first, it.second) },
+                    TimePeriod.MONTHLY to monthly.map { TrendUiModel(it.first, it.second) },
+                    TimePeriod.YEARLY to yearly.map { TrendUiModel(it.first, it.second) }
+                )
+                TrendsUiState.Ready(map, forecast)
+            }.collect { state ->
+                _uiState.value = state
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/trends/components/SpendingTrendLineChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/trends/components/SpendingTrendLineChart.kt
@@ -1,0 +1,99 @@
+package dev.pandesal.sbp.presentation.trends.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.presentation.model.TrendUiModel
+import kotlin.math.max
+
+@Composable
+fun SpendingTrendLineChart(
+    data: List<TrendUiModel>,
+    modifier: Modifier = Modifier,
+    strokeWidth: Dp = 2.dp
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            val color = MaterialTheme.colorScheme.primary
+            Text("Spending Trend", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(modifier = Modifier.weight(1f))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+            ) {
+                if (data.isEmpty()) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("No data available")
+                    }
+                } else {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
+                        val spacing = 16.dp.toPx()
+                        val maxY = data.maxOfOrNull { it.amount } ?: 0.0
+                        if (maxY == 0.0) return@Canvas
+                        val chartHeight = size.height - spacing
+                        val stepX = if (data.size > 1) (size.width - spacing * 2) / (data.size - 1) else 0f
+
+                        val path = Path()
+                        data.forEachIndexed { index, entry ->
+                            val x = spacing + stepX * index
+                            val y = chartHeight * (1f - (entry.amount / maxY).toFloat())
+                            if (index == 0) {
+                                path.moveTo(x, y)
+                            } else {
+                                path.lineTo(x, y)
+                            }
+                        }
+                        drawPath(
+                            path = path,
+                            color = color,
+                            style = Stroke(width = strokeWidth.toPx())
+                        )
+                    }
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(top = 4.dp)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceAround
+                    ) {
+                        data.forEach { entry ->
+                            Text(entry.label, style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## Summary
- introduce TrendUseCase to compute weekly, monthly and yearly spending totals and forecast next month
- add TrendUiModel and spending trend UI components
- implement TrendsViewModel and TrendsScreen
- hook new Trends destination into navigation and bottom toolbar
- bump version to 0.34.0

## Testing
- `./gradlew ktlintFormat` *(fails: No route to host)*