### PR TITLE
Fix blank amount input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.36.1] - 2025-05-20
+### Fixed
+- fix: allow blank amount fields and validate on submit.
+
 ## [0.36.0] - 2025-05-20
 ### Added
 - feat: Add spending trends and forecast screen.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/budget/SetBudgetScreen.kt
@@ -94,7 +94,11 @@ private fun SetBudgetContent(
     onCancel: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-    var amount by remember { mutableStateOf(initialAmount) }
+    var amountText by remember {
+        mutableStateOf(
+            if (initialAmount == BigDecimal.ZERO) "" else initialAmount.toPlainString()
+        )
+    }
     var selectedTab by remember { mutableIntStateOf(0) }
     var showDatePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
@@ -149,8 +153,8 @@ private fun SetBudgetContent(
                             .fillMaxWidth()
                     ) {
                         BasicTextField(
-                            value = amount.toString(),
-                            onValueChange = { amount = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
+                            value = amountText,
+                            onValueChange = { amountText = it },
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(16.dp)
@@ -194,6 +198,7 @@ private fun SetBudgetContent(
             floatingActionButton = {
                 FloatingToolbarDefaults.VibrantFloatingActionButton(
                     onClick = {
+                        val amount = amountText.toBigDecimalOrNull() ?: BigDecimal.ZERO
                         onSubmit(amount, selectedTab == 1, selectedDate.takeIf { selectedTab == 1 })
                         onDismissRequest()
                     },

--- a/app/src/main/java/dev/pandesal/sbp/presentation/goals/NewGoalScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/goals/NewGoalScreen.kt
@@ -73,7 +73,7 @@ private fun NewGoalScreen(
     onDismissRequest: () -> Unit
 ) {
     var name by remember { mutableStateOf("") }
-    var amount by remember { mutableStateOf(BigDecimal.ZERO) }
+    var amountText by remember { mutableStateOf("") }
     var selectedTab by remember { mutableIntStateOf(0) }
     var showDatePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
@@ -119,8 +119,8 @@ private fun NewGoalScreen(
                     modifier = Modifier.fillMaxWidth()
                 )
                 OutlinedTextField(
-                    value = amount.toString(),
-                    onValueChange = { amount = it.toBigDecimalOrNull() ?: BigDecimal.ZERO },
+                    value = amountText,
+                    onValueChange = { amountText = it },
                     label = { Text("Target Amount") },
                     modifier = Modifier
                         .fillMaxWidth()
@@ -177,6 +177,7 @@ private fun NewGoalScreen(
             floatingActionButton = {
                 FloatingToolbarDefaults.VibrantFloatingActionButton(
                     onClick = {
+                        val amount = amountText.toBigDecimalOrNull() ?: BigDecimal.ZERO
                         onSubmit(name, amount, selectedDate.takeIf { selectedTab == 1 })
                         onDismissRequest()
                     }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -354,7 +354,7 @@ private fun NewTransactionScreen(
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Text(
-                                        text = amountText.ifEmpty { "0" },
+                                        text = amountText,
                                         style = MaterialTheme.typography.headlineLarge.copy(
                                             textAlign = TextAlign.Center,
                                             fontSize = 48.sp,

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=36
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- allow empty text for amount fields in budget form, goal form and new transactions
- parse blank amount fields on submit
- update version to 0.36.1
- document changes in changelog

## Testing
- `./gradlew lint` *(fails: No route to host)*