### PR TITLE
Add travel mode banner with customizable tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.38.0] - 2025-05-21
+### Added
+- feat: Show travel mode banner with spending summary.
+- feat: Allow customizing travel tag name.
+
+## [0.37.0] - 2025-05-20
+### Added
+- feat: Introduce travel mode with currency conversion.
+
 ## [0.36.0] - 2025-05-20
 ### Added
 - feat: Add spending trends and forecast screen.

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/SettingsRepository.kt
@@ -23,6 +23,11 @@ class SettingsRepository @Inject constructor(
         val NOTIFICATIONS_ENABLED = booleanPreferencesKey("notifications_enabled")
         val DETECT_FINANCE_APP_USAGE = booleanPreferencesKey("detect_finance_app_usage")
         val CURRENCY = stringPreferencesKey("currency")
+        val TRAVEL_MODE = booleanPreferencesKey("travel_mode")
+        val TRAVEL_CURRENCY = stringPreferencesKey("travel_currency")
+        val TRAVEL_TAG = stringPreferencesKey("travel_tag")
+        val EXCHANGE_RATE = stringPreferencesKey("exchange_rate")
+        val RATE_DATE = stringPreferencesKey("rate_date")
     }
 
     override fun getSettings(): Flow<Settings> =
@@ -31,7 +36,12 @@ class SettingsRepository @Inject constructor(
                 darkMode = prefs[Keys.DARK_MODE] ?: false,
                 notificationsEnabled = prefs[Keys.NOTIFICATIONS_ENABLED] ?: true,
                 detectFinanceAppUsage = prefs[Keys.DETECT_FINANCE_APP_USAGE] ?: false,
-                currency = prefs[Keys.CURRENCY] ?: "PHP"
+                currency = prefs[Keys.CURRENCY] ?: "PHP",
+                isTravelMode = prefs[Keys.TRAVEL_MODE] ?: false,
+                travelCurrency = prefs[Keys.TRAVEL_CURRENCY] ?: "",
+                travelTag = prefs[Keys.TRAVEL_TAG] ?: "Travel",
+                exchangeRate = prefs[Keys.EXCHANGE_RATE]?.toFloatOrNull() ?: 1f,
+                lastRateDate = prefs[Keys.RATE_DATE] ?: ""
             )
         }
 
@@ -49,5 +59,24 @@ class SettingsRepository @Inject constructor(
 
     override suspend fun setCurrency(currency: String) {
         context.settingsDataStore.edit { it[Keys.CURRENCY] = currency }
+    }
+
+    override suspend fun setTravelMode(enabled: Boolean) {
+        context.settingsDataStore.edit { it[Keys.TRAVEL_MODE] = enabled }
+    }
+
+    override suspend fun setTravelCurrency(currency: String) {
+        context.settingsDataStore.edit { it[Keys.TRAVEL_CURRENCY] = currency }
+    }
+
+    override suspend fun setTravelTag(tag: String) {
+        context.settingsDataStore.edit { it[Keys.TRAVEL_TAG] = tag }
+    }
+
+    override suspend fun setExchangeRate(rate: Float, date: String) {
+        context.settingsDataStore.edit {
+            it[Keys.EXCHANGE_RATE] = rate.toString()
+            it[Keys.RATE_DATE] = date
+        }
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -143,5 +143,18 @@ object DataModule {
     ): dev.pandesal.sbp.domain.usecase.ReceiptUseCase =
         dev.pandesal.sbp.domain.usecase.ReceiptUseCase(service)
 
+    @Singleton
+    @Provides
+    fun provideTravelModeUseCase(
+        settingsRepository: SettingsRepositoryInterface,
+        transactionRepository: TransactionRepositoryInterface,
+        exchangeRateService: ExchangeRateService
+    ): dev.pandesal.sbp.domain.usecase.TravelModeUseCase =
+        dev.pandesal.sbp.domain.usecase.TravelModeUseCase(
+            settingsRepository,
+            transactionRepository,
+            exchangeRateService
+        )
+
 
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Settings.kt
@@ -4,5 +4,10 @@ data class Settings(
     val darkMode: Boolean = false,
     val notificationsEnabled: Boolean = true,
     val detectFinanceAppUsage: Boolean = false,
-    val currency: String = "PHP"
+    val currency: String = "PHP",
+    val isTravelMode: Boolean = false,
+    val travelCurrency: String = "",
+    val travelTag: String = "Travel",
+    val exchangeRate: Float = 1f,
+    val lastRateDate: String = ""
 )

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/SettingsRepositoryInterface.kt
@@ -9,4 +9,8 @@ interface SettingsRepositoryInterface {
     suspend fun setNotificationsEnabled(enabled: Boolean)
     suspend fun setDetectFinanceAppUsage(enabled: Boolean)
     suspend fun setCurrency(currency: String)
+    suspend fun setTravelMode(enabled: Boolean)
+    suspend fun setTravelCurrency(currency: String)
+    suspend fun setTravelTag(tag: String)
+    suspend fun setExchangeRate(rate: Float, date: String)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/service/ExchangeRateService.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/service/ExchangeRateService.kt
@@ -1,0 +1,22 @@
+package dev.pandesal.sbp.domain.service
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
+import java.net.HttpURLConnection
+import java.net.URL
+
+class ExchangeRateService {
+    @Serializable
+    private data class Response(val rates: Map<String, Float>)
+
+    suspend fun fetchRate(from: String, to: String): Float {
+        val url = URL("https://api.frankfurter.dev/v1/latest?from=$from&to=$to")
+        val connection = url.openConnection() as HttpURLConnection
+        return connection.inputStream.use { stream ->
+            val text = stream.bufferedReader().readText()
+            val resp = Json.decodeFromString<Response>(text)
+            resp.rates[to] ?: 1f
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/SettingsUseCase.kt
@@ -14,4 +14,8 @@ class SettingsUseCase @Inject constructor(
     suspend fun setNotificationsEnabled(enabled: Boolean) = repository.setNotificationsEnabled(enabled)
     suspend fun setDetectFinanceAppUsage(enabled: Boolean) = repository.setDetectFinanceAppUsage(enabled)
     suspend fun setCurrency(currency: String) = repository.setCurrency(currency)
+    suspend fun setTravelMode(enabled: Boolean) = repository.setTravelMode(enabled)
+    suspend fun setTravelCurrency(currency: String) = repository.setTravelCurrency(currency)
+    suspend fun setTravelTag(tag: String) = repository.setTravelTag(tag)
+    suspend fun setExchangeRate(rate: Float, date: String) = repository.setExchangeRate(rate, date)
 }

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/TravelModeUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/TravelModeUseCase.kt
@@ -1,0 +1,47 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.Settings
+import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
+import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
+import dev.pandesal.sbp.domain.service.ExchangeRateService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import java.math.BigDecimal
+import java.time.LocalDate
+import javax.inject.Inject
+
+class TravelModeUseCase @Inject constructor(
+    private val settingsRepository: SettingsRepositoryInterface,
+    private val transactionRepository: TransactionRepositoryInterface,
+    private val exchangeRateService: ExchangeRateService
+) {
+    fun getSettings(): Flow<Settings> = settingsRepository.getSettings()
+
+    suspend fun setTravelMode(enabled: Boolean) =
+        settingsRepository.setTravelMode(enabled)
+
+    suspend fun setTravelCurrency(currency: String) =
+        settingsRepository.setTravelCurrency(currency)
+
+    suspend fun setTravelTag(tag: String) =
+        settingsRepository.setTravelTag(tag)
+
+    suspend fun refreshRateIfNeeded() {
+        val settings = settingsRepository.getSettings().first()
+        val today = LocalDate.now().toString()
+        if (settings.isTravelMode && settings.lastRateDate != today && settings.travelCurrency.isNotBlank()) {
+            val rate = exchangeRateService.fetchRate(settings.travelCurrency, settings.currency)
+            settingsRepository.setExchangeRate(rate, today)
+        }
+    }
+
+    fun travelSpendHome(): Flow<BigDecimal> = combine(
+        settingsRepository.getSettings(),
+        transactionRepository.getAllTransactions()
+    ) { settings, transactions ->
+        val total = transactions.filter { it.tags.contains(settings.travelTag) }
+            .fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
+        total.multiply(BigDecimal.valueOf(settings.exchangeRate.toDouble()))
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.collectAsState
 import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.components.TravelModeBanner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -67,6 +68,7 @@ class MainActivity : ComponentActivity() {
                 FloatingToolbarDefaults.exitAlwaysScrollBehavior(exitDirection = Bottom)
             val settingsViewModel: dev.pandesal.sbp.presentation.settings.SettingsViewModel = androidx.hilt.navigation.compose.hiltViewModel()
             val settings by settingsViewModel.settings.collectAsState()
+            val travelSpent by settingsViewModel.travelSpent.collectAsState()
             StopBeingPoorTheme(darkTheme = settings.darkMode) {
                 val navController = rememberNavController()
                 var fabVisible by remember { mutableStateOf(true) }
@@ -104,8 +106,16 @@ class MainActivity : ComponentActivity() {
                         Modifier
                             .fillMaxSize()
                             .padding(innerPadding)
-//                            .nestedScroll(scrollConnection)
                     ) {
+                        if (settings.isTravelMode) {
+                            TravelModeBanner(
+                                tag = settings.travelTag,
+                                currency = settings.travelCurrency,
+                                total = travelSpent,
+                                modifier = Modifier.align(Alignment.TopCenter)
+                            )
+                        }
+
                         AppNavigation(navController)
 
                         HorizontalFloatingToolbar(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/components/TravelModeBanner.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/components/TravelModeBanner.kt
@@ -1,0 +1,37 @@
+package dev.pandesal.sbp.presentation.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import java.math.BigDecimal
+
+@Composable
+fun TravelModeBanner(tag: String, currency: String, total: BigDecimal, modifier: Modifier = Modifier) {
+    Surface(
+        color = MaterialTheme.colorScheme.primaryContainer,
+        tonalElevation = 2.dp,
+        modifier = modifier.fillMaxWidth()
+    ) {
+        val text = "Travel: $tag | $currency ${"%,.2f".format(total)}"
+        Text(
+            text = text,
+            modifier = Modifier.padding(8.dp),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TravelModeBannerPreview() {
+    TravelModeBanner("Japan Trip", "JPY", BigDecimal(1234.56))
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.pandesal.sbp.domain.model.Settings
 import dev.pandesal.sbp.domain.usecase.SettingsUseCase
+import dev.pandesal.sbp.domain.usecase.TravelModeUseCase
 import dev.pandesal.sbp.notification.SmsTransactionScanner
 import dev.pandesal.sbp.notification.FinancialAppUsageService
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,12 +21,20 @@ import javax.inject.Inject
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val useCase: SettingsUseCase,
+    private val travelUseCase: TravelModeUseCase,
     private val smsScanner: SmsTransactionScanner,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
 
     val settings: StateFlow<Settings> = useCase.getSettings()
         .stateIn(viewModelScope, SharingStarted.Lazily, Settings())
+
+    val travelSpent: StateFlow<java.math.BigDecimal> = travelUseCase.travelSpendHome()
+        .stateIn(viewModelScope, SharingStarted.Lazily, java.math.BigDecimal.ZERO)
+
+    init {
+        viewModelScope.launch { travelUseCase.refreshRateIfNeeded() }
+    }
 
     fun setDarkMode(enabled: Boolean) {
         viewModelScope.launch { useCase.setDarkMode(enabled) }
@@ -45,6 +54,18 @@ class SettingsViewModel @Inject constructor(
 
     fun setCurrency(currency: String) {
         viewModelScope.launch { useCase.setCurrency(currency) }
+    }
+
+    fun setTravelMode(enabled: Boolean) {
+        viewModelScope.launch { travelUseCase.setTravelMode(enabled) }
+    }
+
+    fun setTravelCurrency(currency: String) {
+        viewModelScope.launch { travelUseCase.setTravelCurrency(currency) }
+    }
+
+    fun setTravelTag(tag: String) {
+        viewModelScope.launch { travelUseCase.setTravelTag(tag) }
     }
 
     fun scanSms() {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagScreen.kt
@@ -1,0 +1,121 @@
+package dev.pandesal.sbp.presentation.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.HorizontalFloatingToolbar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun TravelTagScreen(
+    viewModel: TravelTagViewModel = hiltViewModel(),
+    sheetState: SheetState = rememberModalBottomSheetState(),
+    onDismissRequest: () -> Unit
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    if (state is TravelTagUiState.Ready) {
+        val tag = (state as TravelTagUiState.Ready).tag
+
+        ModalBottomSheet(onDismissRequest = onDismissRequest, sheetState = sheetState) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+                    .imePadding(),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.Top
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+
+                ElevatedCard(
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(50),
+                    elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+                ) {
+                    IconButton(
+                        modifier = Modifier
+                            .height(24.dp)
+                            .padding(4.dp),
+                        onClick = onDismissRequest
+                    ) { Icon(Icons.Filled.Close, contentDescription = null) }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                ElevatedCard(
+                    shape = androidx.compose.foundation.shape.RoundedCornerShape(10),
+                    elevation = CardDefaults.elevatedCardElevation(defaultElevation = 16.dp)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text("Travel Tag")
+                        ElevatedCard(
+                            modifier = Modifier
+                                .padding(top = 4.dp)
+                                .fillMaxWidth()
+                        ) {
+                            BasicTextField(
+                                value = tag,
+                                onValueChange = viewModel::updateTag,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(16.dp)
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                HorizontalFloatingToolbar(
+                    expanded = true,
+                    floatingActionButton = {
+                        FloatingActionButton(
+                            onClick = {
+                                viewModel.save()
+                                onDismissRequest()
+                            },
+                            shape = FloatingActionButtonDefaults.shape,
+                            containerColor = FloatingActionButtonDefaults.containerColor,
+                            contentColor = FloatingActionButtonDefaults.contentColor
+                        ) {
+                            Icon(Icons.Default.Check, contentDescription = null)
+                        }
+                    },
+                    content = {}
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagUiState.kt
@@ -1,0 +1,6 @@
+package dev.pandesal.sbp.presentation.settings
+
+sealed interface TravelTagUiState {
+    data object Loading : TravelTagUiState
+    data class Ready(val tag: String) : TravelTagUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/TravelTagViewModel.kt
@@ -1,0 +1,43 @@
+package dev.pandesal.sbp.presentation.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.usecase.TravelModeUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TravelTagViewModel @Inject constructor(
+    private val travelUseCase: TravelModeUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TravelTagUiState>(TravelTagUiState.Loading)
+    val uiState: StateFlow<TravelTagUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            travelUseCase.getSettings()
+                .map { it.travelTag }
+                .collect { tag ->
+                    _uiState.value = TravelTagUiState.Ready(tag)
+                }
+        }
+    }
+
+    fun updateTag(tag: String) {
+        val current = _uiState.value
+        if (current is TravelTagUiState.Ready) {
+            _uiState.value = current.copy(tag = tag)
+        }
+    }
+
+    fun save() {
+        val current = _uiState.value as? TravelTagUiState.Ready ?: return
+        viewModelScope.launch { travelUseCase.setTravelTag(current.tag) }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=36
+versionMinor=38
 versionPatch=0


### PR DESCRIPTION
## Summary
- show travel mode banner on all screens
- allow customizing travel tag name in settings
- add TravelTagViewModel for tag editing
- bump version to 0.38.0

## Testing
- `./gradlew tasks --all` *(fails: No route to host)*
- `./gradlew --version` *(fails: No route to host)*
- `./gradlew ktlintFormat` *(fails: No route to host)*