### PR TITLE
Fix edit sheets and add goal budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-21
+### Added
+- feat: Show monthly budget suggestion for categories with goals.
+### Fixed
+- fix: Edit buttons on Categories screen now open working rename sheets.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -78,6 +78,8 @@ import dev.pandesal.sbp.extensions.format
 import dev.pandesal.sbp.presentation.categories.budget.SetBudgetScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryGroupScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryScreen
+import dev.pandesal.sbp.presentation.categories.RenameCategoryGroupSheet
+import dev.pandesal.sbp.presentation.categories.RenameCategorySheet
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.categories.components.CategoryBudgetPieChart
 import dev.pandesal.sbp.presentation.goals.GoalsViewModel
@@ -88,6 +90,7 @@ import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.home.components.BudgetSummaryHeader
 import java.time.temporal.ChronoUnit
 import java.time.LocalDate
+import java.math.RoundingMode
 import kotlinx.coroutines.launch
 import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
@@ -259,11 +262,10 @@ private fun CategoriesListContent(
 
 
     if (editGroup != null) {
-        NewCategoryGroupScreen(
-            sheetState = sheetState,
-            initialName = editGroup!!.name,
-            onSubmit = { name ->
-                onEditGroup(editGroup!!, name)
+        RenameCategoryGroupSheet(
+            currentName = editGroup!!.name,
+            onSubmit = {
+                onEditGroup(editGroup!!, it)
                 editGroup = null
             },
             onCancel = { editGroup = null },
@@ -272,14 +274,10 @@ private fun CategoriesListContent(
     }
 
     if (editCategory != null) {
-        NewCategoryScreen(
-            sheetState = newCategorySheetState,
-            groupId = editCategory!!.categoryGroupId,
-            groupName = groupList.firstOrNull { it.id == editCategory!!.categoryGroupId }?.name
-                ?: "",
-            initialName = editCategory!!.name,
-            onSubmit = { name, _ ->
-                onEditCategory(editCategory!!, name)
+        RenameCategorySheet(
+            currentName = editCategory!!.name,
+            onSubmit = {
+                onEditCategory(editCategory!!, it)
                 editCategory = null
             },
             onCancel = { editCategory = null },
@@ -456,9 +454,11 @@ private fun ChildListContent(
                                             val months = ChronoUnit.MONTHS.between(
                                                 LocalDate.now().withDayOfMonth(1),
                                                 it.withDayOfMonth(1)
-                                            ).toInt()
+                                            ).toInt().coerceAtLeast(1)
                                             Text("Due: ${it}")
                                             Text("$months months left")
+                                            val monthly = goal.target.divide(BigDecimal(months), 2, RoundingMode.CEILING)
+                                            Text("Budget: ${monthly.format()}")
                                         }
                                     }
                                 } else {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/RenameCategoryGroupSheet.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/RenameCategoryGroupSheet.kt
@@ -1,0 +1,65 @@
+package dev.pandesal.sbp.presentation.categories
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RenameCategoryGroupSheet(
+    currentName: String,
+    onSubmit: (String) -> Unit,
+    onCancel: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val name = remember { mutableStateOf(currentName) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .imePadding(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("Edit Group Name", style = MaterialTheme.typography.titleLarge)
+            OutlinedTextField(
+                value = name.value,
+                onValueChange = { name.value = it },
+                label = { Text("Group Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                androidx.compose.foundation.layout.Spacer(Modifier.size(8.dp))
+                Button(onClick = { onSubmit(name.value) }, enabled = name.value.isNotBlank()) {
+                    Text("Save")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/RenameCategorySheet.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/RenameCategorySheet.kt
@@ -1,0 +1,65 @@
+package dev.pandesal.sbp.presentation.categories
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RenameCategorySheet(
+    currentName: String,
+    onSubmit: (String) -> Unit,
+    onCancel: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val name = remember { mutableStateOf(currentName) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = sheetState
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .imePadding(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("Edit Category Name", style = MaterialTheme.typography.titleLarge)
+            OutlinedTextField(
+                value = name.value,
+                onValueChange = { name.value = it },
+                label = { Text("Category Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = onCancel) { Text("Cancel") }
+                androidx.compose.foundation.layout.Spacer(Modifier.size(8.dp))
+                Button(onClick = { onSubmit(name.value) }, enabled = name.value.isNotBlank()) {
+                    Text("Save")
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## Summary
- show monthly budget recommendation for categories with goals
- use rename sheets for editing categories and groups
- bump version to 0.34.0

## Testing
- `./gradlew lint` *(fails: No route to host)*