### PR TITLE
feat: show validation errors on new transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-20
+### Added
+- feat: Inline validation errors for New Transaction dialog.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -117,12 +117,13 @@ fun NewTransactionScreen(
             accounts = state.accounts,
             transaction = state.transaction,
             merchants = state.merchants,
+            errors = state.errors,
             editable = editable,
             onEdit = { editable = true },
             onDelete = { showDelete = true },
             onSave = { _, recur, interval, cutoff, reminder ->
-                viewModel.saveTransaction(recur, interval, cutoff, reminder) {
-                    navManager.navigateUp()
+                viewModel.saveTransaction(recur, interval, cutoff, reminder) { success ->
+                    if (success) navManager.navigateUp()
                 }
             },
             onCancel = {
@@ -164,6 +165,7 @@ private fun NewTransactionScreen(
     accounts: List<Account>,
     transaction: Transaction,
     merchants: List<String>,
+    errors: NewTransactionUiState.ValidationErrors,
     editable: Boolean,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
@@ -349,6 +351,14 @@ private fun NewTransactionScreen(
                         )
                     }
                 }
+                if (errors.amount) {
+                    Text(
+                        text = "Amount is required",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.labelSmall,
+                        modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -393,6 +403,15 @@ private fun NewTransactionScreen(
                                         modifier = Modifier.padding(end = 8.dp)
                                     )
                                 }
+
+                            }
+                            if (errors.category) {
+                                Text(
+                                    text = "Category is required",
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.labelSmall,
+                                    modifier = Modifier.padding(start = 16.dp, top = 4.dp)
+                                )
                             }
 
                             if (expanded) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -44,6 +44,9 @@ class NewTransactionsViewModel @Inject constructor(
     private val _merchants = MutableStateFlow<List<String>>(emptyList())
     private var merchantJob: kotlinx.coroutines.Job? = null
 
+    private val _validationErrors =
+        MutableStateFlow(NewTransactionUiState.ValidationErrors())
+
 
     private val _transaction = MutableStateFlow(
         Transaction(
@@ -68,15 +71,17 @@ class NewTransactionsViewModel @Inject constructor(
                 categoryUseCase.getCategories(),
                 accountUseCase.getAccounts(),
                 _transaction,
-                _merchants
-            ) { groups, categories, accounts, transaction, merchants ->
+                _merchants,
+                _validationErrors,
+            ) { groups, categories, accounts, transaction, merchants, errors ->
                 NewTransactionUiState.Success(
                     groupedCategories = groups.associateWith { group ->
                         categories.filter { it.categoryGroupId == group.id }
                     },
                     accounts = accounts,
                     transaction = transaction,
-                    merchants = merchants
+                    merchants = merchants,
+                    errors = errors,
                 )
             }.collect { state ->
                 _uiState.value = state
@@ -92,7 +97,10 @@ class NewTransactionsViewModel @Inject constructor(
                     _merchants.value = merchants
                     val current = _uiState.value
                     if (current is NewTransactionUiState.Success) {
-                        _uiState.value = current.copy(merchants = merchants)
+                        _uiState.value = current.copy(
+                            merchants = merchants,
+                            errors = _validationErrors.value,
+                        )
                     }
                 }
         }
@@ -136,11 +144,18 @@ class NewTransactionsViewModel @Inject constructor(
         }
 
         _transaction.value = newTransaction
+
+        _validationErrors.value = _validationErrors.value.copy(
+            amount = if (newTransaction.amount > BigDecimal.ZERO) false else _validationErrors.value.amount,
+            category = if (newTransaction.category != null) false else _validationErrors.value.category,
+        )
+
         _uiState.value = NewTransactionUiState.Success(
             groupedCategories = (_uiState.value as? NewTransactionUiState.Success)?.groupedCategories ?: mapOf(),
             accounts = (_uiState.value as? NewTransactionUiState.Success)?.accounts ?: listOf(),
             transaction = newTransaction,
-            merchants = _merchants.value
+            merchants = _merchants.value,
+            errors = _validationErrors.value,
         )
     }
 
@@ -153,13 +168,19 @@ class NewTransactionsViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             try {
-                if (_transaction.value.amount <= BigDecimal.ZERO) {
-                    _uiState.value = NewTransactionUiState.Error("Amount is required")
-                    onResult(false)
-                    return@launch
-                }
-                if (_transaction.value.category == null) {
-                    _uiState.value = NewTransactionUiState.Error("Category is required")
+                val amountMissing = _transaction.value.amount <= BigDecimal.ZERO
+                val categoryMissing = _transaction.value.category == null
+
+                _validationErrors.value = NewTransactionUiState.ValidationErrors(
+                    amount = amountMissing,
+                    category = categoryMissing,
+                )
+
+                if (amountMissing || categoryMissing) {
+                    val current = _uiState.value as? NewTransactionUiState.Success
+                    if (current != null) {
+                        _uiState.value = current.copy(errors = _validationErrors.value)
+                    }
                     onResult(false)
                     return@launch
                 }
@@ -174,6 +195,7 @@ class NewTransactionsViewModel @Inject constructor(
                     )
                     recurringTransactionUseCase.addRecurringTransaction(recurring)
                 }
+                _validationErrors.value = NewTransactionUiState.ValidationErrors()
                 onResult(true)
             } catch (e: Exception) {
                 _uiState.value = NewTransactionUiState.Error("Save failed: ${e.localizedMessage}")

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
@@ -8,11 +8,19 @@ import dev.pandesal.sbp.domain.model.Account
 sealed interface NewTransactionUiState {
     data object Initial : NewTransactionUiState
     data object Loading : NewTransactionUiState
+
+    data class ValidationErrors(
+        val amount: Boolean = false,
+        val category: Boolean = false,
+    )
+
     data class Success(
         val groupedCategories: Map<CategoryGroup, List<Category>>,
         val accounts: List<Account>,
         val transaction: Transaction,
-        val merchants: List<String>
+        val merchants: List<String>,
+        val errors: ValidationErrors = ValidationErrors(),
     ) : NewTransactionUiState
+
     data class Error(val errorMessage: String) : NewTransactionUiState
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## Summary
- show validation errors below inputs on New Transaction dialog
- keep dialog open when validation fails
- bump version to 0.34.0

## Testing
- `./gradlew ktlintFormat` *(fails: No route to host)*
- `./gradlew test` *(fails: No route to host)*