### PR TITLE
Fix Transfer categories seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.
 
+## [0.33.1] - 2025-05-20
+### Fixed
+- fix: include default Transfer categories when seeding data.
+
 ## [0.32.0] - 2025-05-20
 ### Added
 - feat: Toggle reminders for recurring transactions.

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/CategoryUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/CategoryUseCase.kt
@@ -125,6 +125,14 @@ class CategoryUseCase @Inject constructor(
                 icon = "",
                 weight = 4,
                 isSystemSet = true
+            ),
+            CategoryGroup(
+                id = 2,
+                name = "Transfers",
+                description = "",
+                icon = "",
+                weight = 5,
+                isSystemSet = true
             )
         )
 
@@ -149,7 +157,10 @@ class CategoryUseCase @Inject constructor(
             Category(24, "Fun Money", "", "", 13, TransactionType.OUTFLOW, 2, isSystemSet = true),
             Category(25, "Credit Card", "", "", 14, TransactionType.OUTFLOW, 0, isSystemSet = true),
             Category(26, "Student Loan", "", "", 14, TransactionType.OUTFLOW, 1, isSystemSet = true),
-            Category(27, "Mortgage", "", "", 14, TransactionType.OUTFLOW, 2, isSystemSet = true)
+            Category(27, "Mortgage", "", "", 14, TransactionType.OUTFLOW, 2, isSystemSet = true),
+            Category(28, "Move Funds", "", "", 2, TransactionType.TRANSFER, 0, isSystemSet = true),
+            Category(29, "Goal Contribution", "", "", 2, TransactionType.TRANSFER, 1, isSystemSet = true),
+            Category(30, "Loan Payment", "", "", 2, TransactionType.TRANSFER, 2, isSystemSet = true)
         )
 
         groups.forEach { repository.insertCategoryGroup(it) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=33
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- include Transfer categories in default seed data
- bump version to 0.33.1

## Testing
- `./gradlew tasks` *(fails: No route to host)*
- `./gradlew test` *(fails: No route to host)*