### PR TITLE
Add category transactions view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.0] - 2025-05-20
+### Added
+- feat: Show transactions when selecting a category.
+
 ## [0.33.0] - 2025-05-20
 ### Added
 - feat: Import only financial SMS and pre-fill transactions via Gemini.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -24,6 +24,7 @@ import dev.pandesal.sbp.presentation.transactions.newtransaction.NewRecurringTra
 import dev.pandesal.sbp.presentation.transactions.recurringdetails.RecurringTransactionDetailsScreen
 import dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsScreen
 import dev.pandesal.sbp.presentation.categories.budget.SetBudgetScreen
+import dev.pandesal.sbp.presentation.categories.CategoryTransactionsScreen
 import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import dev.pandesal.sbp.presentation.goals.NewGoalScreen
@@ -66,6 +67,8 @@ sealed class NavigationDestination() {
     data class SetBudget(val categoryId: Int, val amount: String? = null) : NavigationDestination()
     @Serializable
     data class NewCategory(val groupId: Int, val groupName: String) : NavigationDestination()
+    @Serializable
+    data class CategoryTransactions(val categoryId: Int) : NavigationDestination()
     @Serializable
     data class TransactionDetails(val transactionId: String) : NavigationDestination()
     @Serializable
@@ -127,6 +130,11 @@ fun AppNavigation(navController: NavHostController) {
                     categoryId = args.categoryId,
                     initialAmount = args.amount?.toBigDecimalOrNull() ?: BigDecimal.ZERO
                 )
+            }
+
+            composable<NavigationDestination.CategoryTransactions> { backStackEntry ->
+                val args = backStackEntry.toRoute<NavigationDestination.CategoryTransactions>()
+                CategoryTransactionsScreen(categoryId = args.categoryId)
             }
 
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoriesScreen.kt
@@ -330,7 +330,13 @@ private fun ChildListContent(
                 ReorderableItem(reorderableLazyCategoriesColumnState, item.category.id) {
                     val interactionSource = remember { MutableInteractionSource() }
                     Card(
-                        onClick = {},
+                        onClick = {
+                            navManager.navigate(
+                                NavigationDestination.CategoryTransactions(
+                                    item.category.id
+                                )
+                            )
+                        },
                         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiary),
                         shape = RoundedCornerShape(16.dp),
                         modifier = Modifier

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoryTransactionsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoryTransactionsScreen.kt
@@ -1,0 +1,34 @@
+package dev.pandesal.sbp.presentation.categories
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import dev.pandesal.sbp.presentation.NavigationDestination
+import dev.pandesal.sbp.presentation.components.SkeletonLoader
+import dev.pandesal.sbp.presentation.transactions.TransactionsContent
+import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
+
+@Composable
+fun CategoryTransactionsScreen(
+    categoryId: Int,
+    viewModel: CategoryTransactionsViewModel = hiltViewModel(),
+) {
+    val navManager = LocalNavigationManager.current
+    val uiState = viewModel.uiState.collectAsState()
+
+    LaunchedEffect(categoryId) { viewModel.load(categoryId.toString()) }
+
+    when (val state = uiState.value) {
+        TransactionsUiState.Initial, TransactionsUiState.Loading -> SkeletonLoader()
+        is TransactionsUiState.Success -> {
+            TransactionsContent(
+                transactions = state.transactions,
+                onNewTransactionClick = { navManager.navigate(NavigationDestination.NewTransaction(null)) },
+                onTransactionClick = { navManager.navigate(NavigationDestination.TransactionDetails(it.id)) }
+            )
+        }
+        is TransactionsUiState.Error -> SkeletonLoader()
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoryTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/categories/CategoryTransactionsViewModel.kt
@@ -1,0 +1,29 @@
+package dev.pandesal.sbp.presentation.categories
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.usecase.TransactionUseCase
+import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class CategoryTransactionsViewModel @Inject constructor(
+    private val transactionUseCase: TransactionUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TransactionsUiState>(TransactionsUiState.Initial)
+    val uiState: StateFlow<TransactionsUiState> = _uiState.asStateFlow()
+
+    fun load(categoryId: String) {
+        viewModelScope.launch {
+            transactionUseCase.getTransactionsByCategoryId(categoryId).collect {
+                _uiState.value = TransactionsUiState.Success(it)
+            }
+        }
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/CategoryTransactionsViewModelTest.kt
+++ b/app/src/test/java/dev/pandesal/sbp/CategoryTransactionsViewModelTest.kt
@@ -1,0 +1,46 @@
+package dev.pandesal.sbp
+
+import dev.pandesal.sbp.domain.model.Transaction
+import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.usecase.TransactionUseCase
+import dev.pandesal.sbp.fakes.FakeTransactionRepository
+import dev.pandesal.sbp.fakes.FakeAccountRepository
+import dev.pandesal.sbp.presentation.categories.CategoryTransactionsViewModel
+import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CategoryTransactionsViewModelTest {
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private val repository = FakeTransactionRepository()
+    private val accountRepository = FakeAccountRepository()
+    private val useCase = TransactionUseCase(repository, accountRepository)
+
+    @Test
+    fun uiStateEmitsTransactions() = runTest {
+        val tx = Transaction(
+            name = "t",
+            amount = BigDecimal.ONE,
+            createdAt = LocalDate.now(),
+            updatedAt = LocalDate.now(),
+            from = 1,
+            fromAccountName = "1",
+            transactionType = TransactionType.OUTFLOW
+        )
+        repository.categoryFlow.value = listOf(tx)
+        val vm = CategoryTransactionsViewModel(useCase)
+        vm.load("1")
+        advanceUntilIdle()
+        val state = vm.uiState.value as TransactionsUiState.Success
+        assertEquals(listOf(tx), state.transactions)
+    }
+}

--- a/app/src/test/java/dev/pandesal/sbp/fakes/FakeTransactionRepository.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/FakeTransactionRepository.kt
@@ -12,6 +12,7 @@ import java.time.LocalDate
 class FakeTransactionRepository : TransactionRepositoryInterface {
     val transactionsFlow = MutableStateFlow<List<Transaction>>(emptyList())
     val pagedFlow = MutableStateFlow<List<Transaction>>(emptyList())
+    val categoryFlow = MutableStateFlow<List<Transaction>>(emptyList())
     val merchantsFlow = MutableStateFlow<List<String>>(emptyList())
     val insertedTransactions = mutableListOf<Transaction>()
 
@@ -24,7 +25,7 @@ class FakeTransactionRepository : TransactionRepositoryInterface {
     override fun getTransactionsByTypeAndAccountIdAndDateRange(type: TransactionType, accountId: String, startDate: LocalDate, endDate: LocalDate): Flow<List<Transaction>> = flowOf(emptyList())
     override fun getTransactionById(id: String): Flow<Transaction?> = flowOf(transactionsFlow.value.firstOrNull { it.id == id })
     override fun getTransactionsByAccountId(accountId: String): Flow<List<Transaction>> = flowOf(emptyList())
-    override fun getTransactionsByCategoryId(categoryId: String): Flow<List<Transaction>> = flowOf(emptyList())
+    override fun getTransactionsByCategoryId(categoryId: String): Flow<List<Transaction>> = categoryFlow
     override fun getTransactionsByDateRange(startDate: LocalDate, endDate: LocalDate): Flow<List<Transaction>> = flowOf(emptyList())
     override fun getTransactionsByDateRangeAndAccountId(startDate: LocalDate, endDate: LocalDate, accountId: String): Flow<List<Transaction>> = flowOf(emptyList())
     override fun searchTransactions(query: String): Flow<List<Transaction>> = flowOf(emptyList())

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=33
+versionMinor=34
 versionPatch=0


### PR DESCRIPTION
## Summary
- show list of transactions when tapping a category
- implement `CategoryTransactionsViewModel`
- add `CategoryTransactionsScreen`
- route to new screen from navigation and category list
- bump version to 0.34.0

## Testing
- `./gradlew test` *(fails: No route to host)*