### PR TITLE
Add gradient style to insights charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.39.1] - 2025-05-22
+### Changed
+- style: Add gradient styling to insights charts.
+
 ## [0.39.0] - 2025-05-22
 ### Added
 - feat: Display forecasted trend with dashed line and gradient fill.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/NetWorthBarChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/NetWorthBarChart.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
@@ -106,13 +107,21 @@ fun NetWorthBarChart(
                             val liabilitiesHeight = chartHeight * (entry.liabilities / maxY).toFloat()
                             val xOffset = spacing + index * groupWidth
                             drawRoundRect(
-                                color = primaryColor,
+                                brush = Brush.verticalGradient(
+                                    listOf(primaryColor.copy(alpha = 0.8f), primaryColor.copy(alpha = 0.4f)),
+                                    startY = size.height - assetsHeight,
+                                    endY = size.height
+                                ),
                                 topLeft = Offset(xOffset, size.height - assetsHeight),
                                 size = Size(barWidth.toPx(), assetsHeight),
                                 cornerRadius = CornerRadius(4.dp.toPx())
                             )
                             drawRoundRect(
-                                color = errorColor,
+                                brush = Brush.verticalGradient(
+                                    listOf(errorColor.copy(alpha = 0.8f), errorColor.copy(alpha = 0.4f)),
+                                    startY = size.height - liabilitiesHeight,
+                                    endY = size.height
+                                ),
                                 topLeft = Offset(xOffset + barWidth.toPx() + 4.dp.toPx(), size.height - liabilitiesHeight),
                                 size = Size(barWidth.toPx(), liabilitiesHeight),
                                 cornerRadius = CornerRadius(4.dp.toPx())

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/BudgetVsOutflowChart.kt
@@ -1,7 +1,6 @@
 package dev.pandesal.sbp.presentation.insights.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -30,6 +29,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.model.BudgetOutflowUiModel
@@ -108,13 +108,21 @@ fun BudgetVsOutflowChart(
                             val outflowHeight = chartHeight * (entry.outflow / maxY).toFloat()
                             val xOffset = spacing + index * groupWidth
                             drawRoundRect(
-                                color = primaryColor,
+                                brush = Brush.verticalGradient(
+                                    listOf(primaryColor.copy(alpha = 0.8f), primaryColor.copy(alpha = 0.4f)),
+                                    startY = size.height - budgetHeight,
+                                    endY = size.height
+                                ),
                                 topLeft = Offset(xOffset, size.height - budgetHeight),
                                 size = Size(barWidth.toPx(), budgetHeight),
                                 cornerRadius = CornerRadius(4.dp.toPx())
                             )
                             drawRoundRect(
-                                color = errorColor,
+                                brush = Brush.verticalGradient(
+                                    listOf(errorColor.copy(alpha = 0.8f), errorColor.copy(alpha = 0.4f)),
+                                    startY = size.height - outflowHeight,
+                                    endY = size.height
+                                ),
                                 topLeft = Offset(xOffset + barWidth.toPx() + 4.dp.toPx(), size.height - outflowHeight),
                                 size = Size(barWidth.toPx(), outflowHeight),
                                 cornerRadius = CornerRadius(4.dp.toPx())

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CashflowLineChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CashflowLineChart.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import dev.pandesal.sbp.presentation.model.CashflowUiModel
@@ -80,10 +82,36 @@ fun CashflowLineChart(
                                 outflowPath.lineTo(x, outflowY)
                             }
                         }
+                        val inflowFillPath = Path().apply {
+                            addPath(inflowPath)
+                            lineTo(spacing + stepX * (entries.lastIndex), chartHeight)
+                            lineTo(spacing, chartHeight)
+                            close()
+                        }
+                        val outflowFillPath = Path().apply {
+                            addPath(outflowPath)
+                            lineTo(spacing + stepX * (entries.lastIndex), chartHeight)
+                            lineTo(spacing, chartHeight)
+                            close()
+                        }
+                        drawPath(
+                            path = inflowFillPath,
+                            brush = Brush.verticalGradient(
+                                listOf(primaryColor.copy(alpha = 0.4f), primaryColor.copy(alpha = 0f))
+                            ),
+                            style = Fill
+                        )
                         drawPath(
                             path = inflowPath,
                             color = primaryColor,
                             style = Stroke(width = strokeWidth.toPx())
+                        )
+                        drawPath(
+                            path = outflowFillPath,
+                            brush = Brush.verticalGradient(
+                                listOf(errorColor.copy(alpha = 0.4f), errorColor.copy(alpha = 0f))
+                            ),
+                            style = Fill
                         )
                         drawPath(
                             path = outflowPath,

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=39
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- add gradient fill to CashflowLineChart
- add gradient fill to BudgetVsOutflowChart
- add gradient fill to NetWorthBarChart
- bump version to 0.39.1
- update changelog

## Testing
- `./gradlew test` *(fails: No route to host)*