### PR TITLE
Add daily spend chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.45.0] - 2025-05-24
+### Added
+- feat: Show daily spending bar graph in home header.
+
 ## [0.43.0] - 2025-05-22
 ### Added
 - feat: Simplify Settings screen layout with section headers.

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -58,9 +58,11 @@ import dev.pandesal.sbp.presentation.NavigationDestination
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.components.TransactionItem
 import dev.pandesal.sbp.presentation.home.components.AccountCard
+import dev.pandesal.sbp.presentation.home.components.DailySpendBarChart
 import dev.pandesal.sbp.presentation.model.AccountSummaryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetCategoryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
+import dev.pandesal.sbp.presentation.model.DailySpendUiModel
 import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
 import dev.pandesal.sbp.presentation.transactions.TransactionsContent
 import dev.pandesal.sbp.presentation.transactions.TransactionsUiState
@@ -123,7 +125,7 @@ private fun HomeScreenContent(
     val lazyListState = rememberLazyListState()
     LazyColumn(state = lazyListState) {
         stickyHeader {
-            HeaderSection(totalAmount, onViewNotifications)
+            HeaderSection(totalAmount, state.dailySpent, onViewNotifications)
         }
 
         if (othersPercentage != 100.0) {
@@ -196,6 +198,7 @@ private fun LazyListScope.transactionsSection(
 @Composable
 private fun HeaderSection(
     totalAmount: BigDecimal,
+    dailySpent: List<DailySpendUiModel>,
     onViewNotifications: () -> Unit
 ) {
     ElevatedCard(
@@ -216,11 +219,18 @@ private fun HeaderSection(
             defaultElevation = 16.dp
         )
     ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            AccountSummarySection(totalAmount)
-            HomeToolbar(onViewNotifications)
+        Column {
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                AccountSummarySection(totalAmount)
+                HomeToolbar(onViewNotifications)
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            DailySpendBarChart(entries = dailySpent, modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth())
+            Spacer(modifier = Modifier.height(8.dp))
         }
     }
 }
@@ -386,6 +396,13 @@ fun HomeScreenPreview() {
                     AccountSummaryUiModel("Main", BigDecimal("1200.00"), true, false, "USD")
                 ),
                 netWorthData = emptyList(),
+                dailySpent = listOf(
+                    DailySpendUiModel("MON", 10.0),
+                    DailySpendUiModel("TUE", 20.0),
+                    DailySpendUiModel("WED", 0.0),
+                    DailySpendUiModel("THU", 15.0),
+                    DailySpendUiModel("FRI", 5.0)
+                ),
                 budgetSummary = BudgetSummaryUiModel(0.0, 0.0)
             ),
             transactions = listOf(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeUiState.kt
@@ -4,6 +4,7 @@ import dev.pandesal.sbp.presentation.model.AccountSummaryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetCategoryUiModel
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
+import dev.pandesal.sbp.presentation.model.DailySpendUiModel
 
 sealed interface HomeUiState {
     data object Initial : HomeUiState
@@ -12,6 +13,7 @@ sealed interface HomeUiState {
         val favoriteBudgets: List<BudgetCategoryUiModel>,
         val accounts: List<AccountSummaryUiModel>,
         val netWorthData: List<NetWorthUiModel>,
+        val dailySpent: List<DailySpendUiModel>,
         val budgetSummary: BudgetSummaryUiModel
     ) : HomeUiState
     data class Error(val errorMessage: String) : HomeUiState

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
@@ -11,11 +11,15 @@ import dev.pandesal.sbp.presentation.model.AccountSummaryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetCategoryUiModel
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
 import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
+import dev.pandesal.sbp.presentation.model.DailySpendUiModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -39,6 +43,15 @@ class HomeViewModel @Inject constructor(
             BudgetCategoryUiModel("Dining Out", 1500.0, 800.0, "PHP"),
         )
 
+        val sampleAmounts = listOf(120.0, 90.0, 0.0, 60.0, 30.0)
+        val dummyDailySpent = sampleAmounts.mapIndexed { index, amount ->
+            val date = LocalDate.now().minusDays((4 - index).toLong())
+            DailySpendUiModel(
+                label = date.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault()).uppercase(),
+                amount = amount
+            )
+        }
+
         viewModelScope.launch {
             combine(
                 categoryUseCase.getCategoriesWithLatestBudget(),
@@ -54,6 +67,7 @@ class HomeViewModel @Inject constructor(
                     favoriteBudgets = budgets,
                     accounts = accountsUi,
                     netWorthData = netWorthUi,
+                    dailySpent = dummyDailySpent,
                     budgetSummary = summaryUi
                 )
             }.collect { state ->

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
@@ -1,0 +1,145 @@
+package dev.pandesal.sbp.presentation.home.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.pandesal.sbp.presentation.model.DailySpendUiModel
+import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
+
+@Composable
+fun DailySpendBarChart(
+    entries: List<DailySpendUiModel>,
+    modifier: Modifier = Modifier,
+    barWidth: Dp = 16.dp
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(160.dp),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            val primary = MaterialTheme.colorScheme.primary
+            val secondary = MaterialTheme.colorScheme.secondary
+            Text("Last 5 Days", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+            val maxY = entries.maxOfOrNull { it.amount } ?: 0.0
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier
+                        .width(40.dp)
+                        .height(100.dp),
+                    verticalArrangement = Arrangement.SpaceBetween
+                ) {
+                    for (i in 4 downTo 0) {
+                        Text(
+                            text = "${"%.0f".format(maxY * i / 4)}",
+                            fontSize = 10.sp,
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                    }
+                }
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(100.dp)
+                ) {
+                    Canvas(modifier = Modifier.fillMaxSize()) {
+                        val spacing = barWidth.toPx()
+                        val chartHeight = size.height - spacing
+                        val groupWidth = (size.width - spacing * 2) / entries.size
+
+                        drawRect(
+                            brush = Brush.verticalGradient(
+                                listOf(
+                                    MaterialTheme.colorScheme.surfaceVariant,
+                                    MaterialTheme.colorScheme.surface
+                                )
+                            ),
+                            size = size
+                        )
+
+                        entries.forEachIndexed { index, entry ->
+                            val xOffset = spacing + index * groupWidth + (groupWidth - barWidth.toPx()) / 2
+                            if (entry.amount > 0) {
+                                val barHeight = if (maxY == 0.0) 0f else chartHeight * (entry.amount / maxY).toFloat()
+                                drawRoundRect(
+                                    brush = Brush.verticalGradient(listOf(primary, secondary)),
+                                    topLeft = Offset(xOffset, size.height - barHeight),
+                                    size = Size(barWidth.toPx(), barHeight),
+                                    cornerRadius = CornerRadius(4.dp.toPx())
+                                )
+                            } else {
+                                val dashHeight = chartHeight * 0.2f
+                                drawLine(
+                                    color = MaterialTheme.colorScheme.outline,
+                                    start = Offset(xOffset + barWidth.toPx() / 2, size.height),
+                                    end = Offset(xOffset + barWidth.toPx() / 2, size.height - dashHeight),
+                                    strokeWidth = barWidth.toPx(),
+                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f))
+                                )
+                            }
+                        }
+                    }
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(top = 4.dp)
+                            .fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceAround
+                    ) {
+                        entries.forEach { entry ->
+                            Text(entry.label, style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@androidx.compose.ui.tooling.preview.Preview
+fun DailySpendBarChartPreview() {
+    StopBeingPoorTheme {
+        DailySpendBarChart(
+            entries = listOf(
+                DailySpendUiModel("MON", 10.0),
+                DailySpendUiModel("TUE", 20.0),
+                DailySpendUiModel("WED", 0.0),
+                DailySpendUiModel("THU", 15.0),
+                DailySpendUiModel("FRI", 5.0)
+            )
+        )
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/DailySpendUiModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/DailySpendUiModel.kt
@@ -1,0 +1,7 @@
+package dev.pandesal.sbp.presentation.model
+
+/** Model for daily spending amounts */
+data class DailySpendUiModel(
+    val label: String,
+    val amount: Double
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=44
+versionMinor=45
 versionPatch=0


### PR DESCRIPTION
## Summary
- show sample daily spending data in HomeViewModel
- add DailySpendUiModel and DailySpendBarChart composable
- display the new bar chart in HomeScreen header
- bump version to 0.45.0

## Testing
- `./gradlew test` *(fails: No route to host)*
- `./gradlew lint` *(fails: No route to host)*