### PR TITLE
fix: enforce unique monthly budget entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.47.1] - 2025-05-24
+### Fixed
+- fix: enforce unique monthly budget entries per category-month.
+
 ## [0.45.0] - 2025-05-23
 ### Added
 - feat: Merge Insights and Trends screen with improved charts.

--- a/app/src/main/java/dev/pandesal/sbp/data/local/Category.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/Category.kt
@@ -3,6 +3,7 @@ package dev.pandesal.sbp.data.local
 import androidx.room.ColumnInfo
 import androidx.room.Embedded
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import dev.pandesal.sbp.domain.model.Category
 import dev.pandesal.sbp.domain.model.CategoryGroup
@@ -38,7 +39,10 @@ data class CategoryEntity(
     val isSystemSet: Boolean = false,
 )
 
-@Entity(tableName = "monthly_budgets")
+@Entity(
+    tableName = "monthly_budgets",
+    indices = [Index(value = ["categoryId", "yearMonth"], unique = true)]
+)
 data class MonthlyBudgetEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val categoryId: Int,

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -29,7 +29,7 @@ import java.math.BigDecimal
         AccountEntity::class,
         GoalEntity::class,
         RecurringTransactionEntity::class],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 @TypeConverters(BigDecimalConverter::class, ListStringConverter::class)

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=47
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- enforce unique monthly budget records per category and month
- bump DB version to trigger migration
- bump patch version to 0.47.1

## Testing
- `./gradlew lint` *(fails: No route to host)*
- `./gradlew test` *(fails: No route to host)*