### PR TITLE
feat: home empty daily expense state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.49.0] - 2025-05-25
+### Added
+- feat: Show placeholder daily spending chart when no data is available
 ## [0.48.0] - 2025-05-24
 ### Added
 - feat: Load real data for daily spending chart

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -403,7 +403,8 @@ fun HomeScreenPreview() {
                         DailySpend("THU", BigDecimal("15.0")),
                         DailySpend("FRI", BigDecimal("5.0"))
                     ),
-                    changeFromLastWeek = 10.0
+                    changeFromLastWeek = 10.0,
+                    hasData = true
                 ),
                 budgetSummary = BudgetSummaryUiModel(BigDecimal.ZERO, BigDecimal.ZERO),
                 currency = "USD"

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import java.math.BigDecimal
+import kotlin.random.Random
 import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale
@@ -77,13 +78,22 @@ class HomeViewModel @Inject constructor(
                         amount = grouped[date]?.fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount } ?: BigDecimal.ZERO
                     )
                 }
+                val hasData = entries.any { it.amount > BigDecimal.ZERO }
                 val currentTotal = entries.fold(BigDecimal.ZERO) { acc, d -> acc + d.amount }
                 val prevTotal = prevTx.fold(BigDecimal.ZERO) { acc, tx -> acc + tx.amount }
                 val change = if (prevTotal == BigDecimal.ZERO) 0.0 else ((currentTotal - prevTotal)
                     .divide(prevTotal, java.math.MathContext.DECIMAL64)
                     .toDouble() * 100)
 
-                val dailySpent = DailySpendUiModel(entries, change)
+                val displayEntries = if (hasData) {
+                    entries
+                } else {
+                    entries.map {
+                        it.copy(amount = BigDecimal(Random.nextInt(10, 100)))
+                    }
+                }
+
+                val dailySpent = DailySpendUiModel(displayEntries, change, hasData)
 
                 HomeUiState.Success(
                     favoriteBudgets = budgets,

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
@@ -1,8 +1,8 @@
 package dev.pandesal.sbp.presentation.home.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +10,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,10 +46,15 @@ fun DailySpendBarChart(
     Column(
         modifier = modifier
     ) {
-        val arrow = if (dailySpendUiModel.changeFromLastWeek >= 0) "\u2191" else "\u2193"
-        val changeText = String.format("%.0f", kotlin.math.abs(dailySpendUiModel.changeFromLastWeek))
+        val headerText = if (dailySpendUiModel.hasData) {
+            val arrow = if (dailySpendUiModel.changeFromLastWeek >= 0) "\u2191" else "\u2193"
+            val changeText = String.format("%.0f", kotlin.math.abs(dailySpendUiModel.changeFromLastWeek))
+            "Your spending this week $arrow$changeText%"
+        } else {
+            "Your data will show here"
+        }
         Text(
-            "Your spending this week $arrow$changeText%",
+            headerText,
             style = MaterialTheme.typography.labelMedium
         )
         Spacer(modifier = Modifier.height(16.dp))
@@ -65,7 +75,7 @@ fun DailySpendBarChart(
                     val percentage = if (maxY == BigDecimal.ZERO) 0f else (entry.amount / maxY).toFloat()
                     val barFillHeight = chartHeight * percentage
 
-                    if (index == dailySpendUiModel.entries.lastIndex) {
+                    if (dailySpendUiModel.hasData && index == dailySpendUiModel.entries.lastIndex) {
                         val prev = dailySpendUiModel.entries.getOrNull(index - 1)?.amount ?: BigDecimal.ZERO
                         val diff = if (prev == BigDecimal.ZERO) 0.0 else ((entry.amount - prev)
                             .divide(prev, java.math.MathContext.DECIMAL64)
@@ -80,23 +90,34 @@ fun DailySpendBarChart(
                         )
                     }
 
-                    Box(
-                        modifier = Modifier
-                            .height(barFillHeight)
-                            .width(barWidth)
-                            .background(
-                                brush = if (index == dailySpendUiModel.entries.lastIndex) {
-                                    if (entry.amount > BigDecimal.ZERO) {
-                                        Brush.verticalGradient(listOf(primary, secondary))
-                                    } else {
-                                        Brush.verticalGradient(listOf(outline, outline))
-                                    }
+                    val barModifier = Modifier
+                        .height(barFillHeight)
+                        .width(barWidth)
+                        .clip(RoundedCornerShape(12.dp))
+
+                    val finalModifier = if (dailySpendUiModel.hasData) {
+                        barModifier.background(
+                            brush = if (index == dailySpendUiModel.entries.lastIndex) {
+                                if (entry.amount > BigDecimal.ZERO) {
+                                    Brush.verticalGradient(listOf(primary, secondary))
                                 } else {
-                                    Brush.verticalGradient(listOf(Color.LightGray, Color.LightGray))
-                                },
-                                shape = RoundedCornerShape(12.dp)
+                                    Brush.verticalGradient(listOf(outline, outline))
+                                }
+                            } else {
+                                Brush.verticalGradient(listOf(Color.LightGray, Color.LightGray))
+                            }
+                        )
+                    } else {
+                        barModifier.drawBehind {
+                            drawRoundRect(
+                                color = outline,
+                                cornerRadius = CornerRadius(12.dp.toPx()),
+                                style = Stroke(width = 1.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f)))
                             )
-                    )
+                        }
+                    }
+
+                    Box(modifier = finalModifier)
 
                 }
             }
@@ -135,7 +156,8 @@ fun DailySpendBarChartPreview() {
                     DailySpend("THU", BigDecimal("15.0")),
                     DailySpend("FRI", BigDecimal("5.0"))
                 ),
-                changeFromLastWeek = 0.0
+                changeFromLastWeek = 0.0,
+                hasData = true
             )
         )
     }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/DailySpendUiModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/DailySpendUiModel.kt
@@ -5,8 +5,8 @@ import java.math.BigDecimal
 /** Model for daily spending amounts */
 data class DailySpendUiModel(
     val entries: List<DailySpend>,
-    val changeFromLastWeek: Double
-
+    val changeFromLastWeek: Double,
+    val hasData: Boolean = true
 )
 
 data class DailySpend(

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=48
+versionMinor=49
 versionPatch=0


### PR DESCRIPTION
## Summary
- show placeholder daily spending chart when there is no real data
- support placeholder state in `DailySpendUiModel`
- bump version to 0.49.0

## Testing
- `./gradlew --no-daemon ktlintFormat` *(fails: No route to host)*