### PR TITLE
Fix transaction form retention and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.49.1] - 2025-05-25
+### Fixed
+- fix: keep input values on validation errors
+- fix: auto select default category when switching type
+- fix: prefill dropdowns when editing transactions
 ## [0.49.0] - 2025-05-25
 ### Added
 - feat: Show placeholder daily spending chart when no data is available

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=49
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- keep field values on validation error
- auto-select default category on type switch
- show account/category when editing transactions
- bump version to 0.49.1

## Testing
- `./gradlew ktlintFormat` *(fails: No route to host)*