### PR TITLE
Add pull-to-refresh to HomeScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.49.0] - 2025-05-25
+### Added
+- feat: Enable pull to refresh on home screen
 ## [0.48.0] - 2025-05-24
 ### Added
 - feat: Load real data for daily spending chart

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
 
     implementation(libs.coil.compose)
     implementation(libs.lottie.compose)
+    implementation(libs.androidx.pullrefresh)
     implementation(libs.reorderable)
     implementation(libs.mlkit.text.recognition)
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeViewModel.kt
@@ -39,10 +39,17 @@ class HomeViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<HomeUiState> = MutableStateFlow(HomeUiState.Initial)
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
-    init {
-        _uiState.value = HomeUiState.Loading
+    private var loadJob: kotlinx.coroutines.Job? = null
 
-        viewModelScope.launch {
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = HomeUiState.Loading
+
             val today = LocalDate.now()
             val start = today.minusDays(6)
             val prevStart = start.minusDays(7)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/TransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/TransactionsViewModel.kt
@@ -1,25 +1,14 @@
 package dev.pandesal.sbp.presentation.transactions
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dev.pandesal.sbp.domain.model.Category
-import dev.pandesal.sbp.domain.model.CategoryGroup
-import dev.pandesal.sbp.domain.model.MonthlyBudget
-import dev.pandesal.sbp.domain.model.TransactionType
-import dev.pandesal.sbp.domain.usecase.CategoryUseCase
 import dev.pandesal.sbp.domain.usecase.TransactionUseCase
-import dev.pandesal.sbp.presentation.categories.CategoriesUiState
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import java.math.BigDecimal
-import java.time.YearMonth
 import javax.inject.Inject
 
 @HiltViewModel
@@ -29,13 +18,16 @@ class TransactionsViewModel @Inject constructor(
 
     private val _uiState: MutableStateFlow<TransactionsUiState> = MutableStateFlow(TransactionsUiState.Initial)
     val uiState: StateFlow<TransactionsUiState> = _uiState.asStateFlow()
+    private var loadJob: Job? = null
 
     init {
-        observeData()
+        refresh()
     }
 
-    private fun observeData() {
-        viewModelScope.launch {
+    fun refresh() {
+        loadJob?.cancel()
+        loadJob = viewModelScope.launch {
+            _uiState.value = TransactionsUiState.Loading
             useCase.getPagedTransactions(50, 0)
                 .collect { transactions ->
                     _uiState.value = TransactionsUiState.Success(transactions)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=48
+versionMinor=49
 versionPatch=0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkitText" }
+androidx-pullrefresh = { group = "androidx.compose.material", name = "pullrefresh" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- enable pull-to-refresh on the Home screen
- add pull refresh dependency
- make Home and Transactions view models refreshable
- bump version to 0.49.0

## Testing
- `./gradlew lint` *(fails: No route to host)*