### PR TITLE
Add date tooltip with reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.50.0] - 2025-05-22
+### Added
+- feat: Show tooltip with daily details and reminders on calendar dates
+
+## [0.50.1] - 2025-05-22
+### Fixed
+- fix: Refine tooltip anchor, styling, and calendar highlights
+
 
 ## [0.49.2] - 2025-05-25
 ### Fixed

--- a/app/src/main/java/dev/pandesal/sbp/data/dao/DatabaseDaos.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/dao/DatabaseDaos.kt
@@ -6,4 +6,5 @@ interface DatabaseDaos {
     fun accountDao(): AccountDao
     fun goalDao(): GoalDao
     fun recurringTransactionDao(): RecurringTransactionDao
+    fun reminderDao(): ReminderDao
 }

--- a/app/src/main/java/dev/pandesal/sbp/data/dao/ReminderDao.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/dao/ReminderDao.kt
@@ -1,0 +1,23 @@
+package dev.pandesal.sbp.data.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import dev.pandesal.sbp.data.local.ReminderEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ReminderDao {
+    @Query("SELECT * FROM reminders")
+    fun getReminders(): Flow<List<ReminderEntity>>
+
+    @Query("SELECT * FROM reminders WHERE date = :date")
+    fun getRemindersByDate(date: String): Flow<List<ReminderEntity>>
+
+    @Upsert
+    suspend fun insert(value: ReminderEntity)
+
+    @Delete
+    suspend fun delete(value: ReminderEntity)
+}

--- a/app/src/main/java/dev/pandesal/sbp/data/local/Reminder.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/Reminder.kt
@@ -1,0 +1,25 @@
+package dev.pandesal.sbp.data.local
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import dev.pandesal.sbp.domain.model.Reminder
+import java.time.LocalDate
+
+@Entity(tableName = "reminders")
+data class ReminderEntity(
+    @PrimaryKey val id: String,
+    val date: String,
+    val message: String
+)
+
+fun ReminderEntity.toDomainModel() = Reminder(
+    id = id,
+    date = LocalDate.parse(date),
+    message = message
+)
+
+fun Reminder.toEntity() = ReminderEntity(
+    id = id,
+    date = date.toString(),
+    message = message
+)

--- a/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/local/SbpDatabase.kt
@@ -14,9 +14,11 @@ import dev.pandesal.sbp.data.dao.CategoryDao
 import dev.pandesal.sbp.data.dao.TransactionDao
 import dev.pandesal.sbp.data.dao.GoalDao
 import dev.pandesal.sbp.data.dao.RecurringTransactionDao
+import dev.pandesal.sbp.data.dao.ReminderDao
 import dev.pandesal.sbp.data.local.AccountEntity
 import dev.pandesal.sbp.data.local.GoalEntity
 import dev.pandesal.sbp.data.local.RecurringTransactionEntity
+import dev.pandesal.sbp.data.local.ReminderEntity
 import kotlinx.serialization.json.Json
 import java.math.BigDecimal
 
@@ -28,8 +30,9 @@ import java.math.BigDecimal
         TransactionEntity::class,
         AccountEntity::class,
         GoalEntity::class,
-        RecurringTransactionEntity::class],
-    version = 7,
+        RecurringTransactionEntity::class,
+        ReminderEntity::class],
+    version = 8,
     exportSchema = false
 )
 @TypeConverters(BigDecimalConverter::class, ListStringConverter::class)
@@ -40,6 +43,7 @@ abstract class SbpDatabase : RoomDatabase(), DatabaseDaos {
     abstract override fun accountDao(): AccountDao
     abstract override fun goalDao(): GoalDao
     abstract override fun recurringTransactionDao(): RecurringTransactionDao
+    abstract override fun reminderDao(): ReminderDao
 
     companion object {
 

--- a/app/src/main/java/dev/pandesal/sbp/data/repository/ReminderRepository.kt
+++ b/app/src/main/java/dev/pandesal/sbp/data/repository/ReminderRepository.kt
@@ -1,0 +1,31 @@
+package dev.pandesal.sbp.data.repository
+
+import dev.pandesal.sbp.data.dao.ReminderDao
+import dev.pandesal.sbp.data.local.toDomainModel
+import dev.pandesal.sbp.data.local.toEntity
+import dev.pandesal.sbp.domain.model.Reminder
+import dev.pandesal.sbp.domain.repository.ReminderRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReminderRepository @Inject constructor(
+    private val dao: ReminderDao
+) : ReminderRepositoryInterface {
+    override fun getReminders(): Flow<List<Reminder>> =
+        dao.getReminders().map { list -> list.map { it.toDomainModel() } }
+
+    override fun getRemindersByDate(date: LocalDate): Flow<List<Reminder>> =
+        dao.getRemindersByDate(date.toString()).map { it.map { it.toDomainModel() } }
+
+    override suspend fun upsertReminder(reminder: Reminder) {
+        dao.insert(reminder.toEntity())
+    }
+
+    override suspend fun deleteReminder(reminder: Reminder) {
+        dao.delete(reminder.toEntity())
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
+++ b/app/src/main/java/dev/pandesal/sbp/di/DataModule.kt
@@ -11,6 +11,7 @@ import dev.pandesal.sbp.data.dao.TransactionDao
 import dev.pandesal.sbp.data.dao.AccountDao
 import dev.pandesal.sbp.data.dao.GoalDao
 import dev.pandesal.sbp.data.dao.RecurringTransactionDao
+import dev.pandesal.sbp.data.dao.ReminderDao
 import dev.pandesal.sbp.data.local.SbpDatabase
 import dev.pandesal.sbp.data.repository.CategoryRepository
 import dev.pandesal.sbp.data.repository.TransactionRepository
@@ -18,12 +19,14 @@ import dev.pandesal.sbp.data.repository.AccountRepository
 import dev.pandesal.sbp.data.repository.GoalRepository
 import dev.pandesal.sbp.data.repository.SettingsRepository
 import dev.pandesal.sbp.data.repository.RecurringTransactionRepository
+import dev.pandesal.sbp.data.repository.ReminderRepository
 import dev.pandesal.sbp.domain.repository.CategoryRepositoryInterface
 import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
 import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
 import dev.pandesal.sbp.domain.repository.GoalRepositoryInterface
 import dev.pandesal.sbp.domain.repository.SettingsRepositoryInterface
 import dev.pandesal.sbp.domain.repository.RecurringTransactionRepositoryInterface
+import dev.pandesal.sbp.domain.repository.ReminderRepositoryInterface
 import dev.pandesal.sbp.domain.service.ExchangeRateService
 import dev.pandesal.sbp.notification.SmsTransactionScanner
 import javax.inject.Singleton
@@ -68,6 +71,12 @@ object DataModule {
     @Provides
     fun provideRecurringTransactionDao(database: SbpDatabase): RecurringTransactionDao {
         return database.recurringTransactionDao()
+    }
+
+    @Singleton
+    @Provides
+    fun provideReminderDao(database: SbpDatabase): ReminderDao {
+        return database.reminderDao()
     }
 
     @Singleton
@@ -117,6 +126,14 @@ object DataModule {
         dao: RecurringTransactionDao
     ): RecurringTransactionRepositoryInterface {
         return RecurringTransactionRepository(dao)
+    }
+
+    @Singleton
+    @Provides
+    fun provideReminderRepository(
+        dao: ReminderDao
+    ): ReminderRepositoryInterface {
+        return ReminderRepository(dao)
     }
 
     @Singleton

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Reminder.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Reminder.kt
@@ -1,0 +1,13 @@
+package dev.pandesal.sbp.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.time.LocalDate
+import java.util.UUID
+
+@Parcelize
+data class Reminder(
+    val id: String = UUID.randomUUID().toString(),
+    val date: LocalDate,
+    val message: String
+) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/ReminderRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/ReminderRepositoryInterface.kt
@@ -1,0 +1,12 @@
+package dev.pandesal.sbp.domain.repository
+
+import dev.pandesal.sbp.domain.model.Reminder
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+
+interface ReminderRepositoryInterface {
+    fun getReminders(): Flow<List<Reminder>>
+    fun getRemindersByDate(date: LocalDate): Flow<List<Reminder>>
+    suspend fun upsertReminder(reminder: Reminder)
+    suspend fun deleteReminder(reminder: Reminder)
+}

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/ReminderUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/ReminderUseCase.kt
@@ -1,0 +1,20 @@
+package dev.pandesal.sbp.domain.usecase
+
+import dev.pandesal.sbp.domain.model.Reminder
+import dev.pandesal.sbp.domain.repository.ReminderRepositoryInterface
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import javax.inject.Inject
+
+class ReminderUseCase @Inject constructor(
+    private val repository: ReminderRepositoryInterface
+) {
+    fun getReminders(): Flow<List<Reminder>> = repository.getReminders()
+
+    fun getRemindersByDate(date: LocalDate): Flow<List<Reminder>> =
+        repository.getRemindersByDate(date)
+
+    suspend fun upsertReminder(reminder: Reminder) = repository.upsertReminder(reminder)
+
+    suspend fun deleteReminder(reminder: Reminder) = repository.deleteReminder(reminder)
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/DayTooltipUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/DayTooltipUiState.kt
@@ -1,0 +1,15 @@
+package dev.pandesal.sbp.presentation.insights
+
+import dev.pandesal.sbp.domain.model.Reminder
+import dev.pandesal.sbp.domain.model.RecurringTransaction
+import dev.pandesal.sbp.domain.model.Transaction
+
+sealed interface DayTooltipUiState {
+    data object Loading : DayTooltipUiState
+    data class Ready(
+        val transactions: List<Transaction>,
+        val recurring: List<RecurringTransaction>,
+        val reminders: List<Reminder>
+    ) : DayTooltipUiState
+    data class Error(val message: String) : DayTooltipUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -18,15 +19,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import androidx.hilt.navigation.compose.hiltViewModel
 import java.time.YearMonth
+import java.time.LocalDate
 import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.components.TimePeriodDropdown
 import dev.pandesal.sbp.presentation.home.components.NetWorthBarChart
 import dev.pandesal.sbp.presentation.insights.components.BudgetVsOutflowChart
 import dev.pandesal.sbp.presentation.insights.components.CalendarView
 import dev.pandesal.sbp.presentation.insights.components.CashflowLineChart
+import dev.pandesal.sbp.presentation.insights.components.DateTooltip
+import dev.pandesal.sbp.presentation.reminders.ReminderFormDialog
 import dev.pandesal.sbp.presentation.trends.TrendsViewModel
 import dev.pandesal.sbp.presentation.trends.TrendsUiState
 import dev.pandesal.sbp.presentation.trends.components.SpendingTrendLineChart
@@ -47,20 +54,25 @@ fun InsightsScreen(
     var netWorthPeriod by remember { mutableStateOf(period) }
     var trendChartPeriod by remember { mutableStateOf(trendPeriod) }
     var calendarMonth by remember { mutableStateOf(YearMonth.now()) }
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    var tooltipOffset by remember { mutableStateOf(IntOffset.Zero) }
+    var showReminderForm by remember { mutableStateOf(false) }
+    val tooltip by viewModel.tooltipState.collectAsState()
 
     if (state is InsightsUiState.Initial) {
         SkeletonLoader()
     } else if (state is InsightsUiState.Success) {
         val data = state as InsightsUiState.Success
-        Column(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .padding(16.dp)
-        ) {
-            Text(
-                text = "Insights",
-                style = MaterialTheme.typography.titleLargeEmphasized
-            )
+        Box {
+            Column(
+                modifier = Modifier
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp)
+            ) {
+                Text(
+                    text = "Insights",
+                    style = MaterialTheme.typography.titleLargeEmphasized
+                )
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -68,7 +80,13 @@ fun InsightsScreen(
             CalendarView(
                 events = monthEvents,
                 month = calendarMonth,
-                onMonthChange = { calendarMonth = it }
+                selectedDate = selectedDate,
+                onMonthChange = { calendarMonth = it },
+                onDateClick = { date, offset ->
+                    selectedDate = date
+                    tooltipOffset = offset
+                    viewModel.loadDayDetails(date)
+                }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -80,6 +98,8 @@ fun InsightsScreen(
                     period = cashflowPeriod, onPeriodChange = { cashflowPeriod = it }
                 )
             }
+
+        }
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -123,6 +143,26 @@ fun InsightsScreen(
             }
             Spacer(modifier = Modifier.height(140.dp))
         }
+
+        selectedDate?.let { date ->
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(Color.Black.copy(alpha = 0.5f))
+            )
+            Popup(alignment = Alignment.TopStart, offset = tooltipOffset) {
+                DateTooltip(
+                    date = date,
+                    state = tooltip,
+                    onClose = { selectedDate = null },
+                    onAddReminder = { showReminderForm = true }
+                )
+            }
+        }
+    }
+
+    if (showReminderForm && selectedDate != null) {
+        ReminderFormDialog(date = selectedDate!!) { showReminderForm = false }
     }
 }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -1,15 +1,20 @@
 package dev.pandesal.sbp.presentation.insights.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.bringIntoViewRequester
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.foundation.layout.BringIntoViewRequester
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -25,8 +30,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInRoot
 import dev.pandesal.sbp.presentation.model.CalendarEvent
 import dev.pandesal.sbp.presentation.model.CalendarEventType
+import java.time.LocalDate
 import java.time.DayOfWeek
 import java.time.YearMonth
 import java.time.format.TextStyle
@@ -36,7 +47,9 @@ import java.util.Locale
 fun CalendarView(
     events: List<CalendarEvent>,
     month: YearMonth,
+    selectedDate: LocalDate?,
     onMonthChange: (YearMonth) -> Unit,
+    onDateClick: (LocalDate, IntOffset) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val monthStart = month.atDay(1)
@@ -44,6 +57,7 @@ fun CalendarView(
     val firstDayOffset = monthStart.dayOfWeek.ordinal
     val grouped = events.groupBy { it.date }
 
+    val scope = rememberCoroutineScope()
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = CardDefaults.shape,
@@ -91,10 +105,47 @@ fun CalendarView(
                         if (day in 1..daysInMonth) {
                             val date = monthStart.plusDays((day - 1).toLong())
                             val dayEvents = grouped[date].orEmpty()
+                            val bring = BringIntoViewRequester()
+                            var coords: LayoutCoordinates? = null
                             Column(
-                                modifier = Modifier.weight(1f).height(50.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally) {
-                                Text(day.toString(), style = MaterialTheme.typography.bodySmall, textAlign = TextAlign.End)
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(50.dp)
+                                    .bringIntoViewRequester(bring)
+                                    .onGloballyPositioned { coords = it }
+                                    .clickable {
+                                        scope.launch { bring.bringIntoView() }
+                                        val pos = coords?.positionInRoot() ?: Offset.Zero
+                                        onDateClick(date, IntOffset(pos.x.toInt(), pos.y.toInt()))
+                                    },
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                val isToday = date == LocalDate.now()
+                                val isSelected = selectedDate == date
+                                Box(
+                                    modifier = Modifier
+                                        .padding(2.dp)
+                                        .background(
+                                            when {
+                                                isSelected -> MaterialTheme.colorScheme.primaryContainer
+                                                isToday -> MaterialTheme.colorScheme.secondaryContainer
+                                                else -> Color.Transparent
+                                            },
+                                            CircleShape
+                                        )
+                                        .border(
+                                            width = if (isSelected) 1.dp else 0.dp,
+                                            color = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent,
+                                            shape = CircleShape
+                                        )
+                                        .padding(horizontal = 6.dp, vertical = 2.dp)
+                                ) {
+                                    Text(
+                                        day.toString(),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
                                 Row {
                                     dayEvents.forEach { event ->
                                         Box(

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/DateTooltip.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/DateTooltip.kt
@@ -1,0 +1,102 @@
+package dev.pandesal.sbp.presentation.insights.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import dev.pandesal.sbp.presentation.insights.DayTooltipUiState
+import dev.pandesal.sbp.presentation.components.TransactionItem
+
+@Composable
+fun DateTooltip(
+    date: LocalDate,
+    modifier: Modifier = Modifier,
+    state: DayTooltipUiState,
+    onClose: () -> Unit,
+    onAddReminder: () -> Unit,
+) {
+    AnimatedVisibility(
+        visible = state is DayTooltipUiState.Ready,
+        enter = fadeIn() + scaleIn(),
+        exit = fadeOut() + scaleOut(),
+        modifier = modifier
+    ) {
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            elevation = CardDefaults.cardElevation(8.dp),
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            val ready = state as? DayTooltipUiState.Ready
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = date.format(DateTimeFormatter.ofPattern("MMM d, yyyy")),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.weight(1f)
+                    )
+                    IconButton(onClick = onAddReminder) {
+                        Icon(Icons.Default.Add, contentDescription = "Add")
+                    }
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.Default.Close, contentDescription = "Close")
+                    }
+                }
+                ready?.transactions?.takeIf { it.isNotEmpty() }?.let { txs ->
+                    Text("Transactions", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = 8.dp))
+                    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(8.dp)) {
+                            txs.forEach { tx -> TransactionItem(tx) }
+                        }
+                    }
+                }
+                ready?.recurring?.takeIf { it.isNotEmpty() }?.let { recs ->
+                    Text("Recurring", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = 8.dp))
+                    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(8.dp)) {
+                            recs.forEach { rec -> TransactionItem(rec.transaction) }
+                        }
+                    }
+                }
+                ready?.reminders?.takeIf { it.isNotEmpty() }?.let { rems ->
+                    Text("Reminders", style = MaterialTheme.typography.titleMedium, modifier = Modifier.padding(top = 8.dp))
+                    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                        Column(modifier = Modifier.padding(8.dp)) {
+                            rems.forEach { r -> Text("• ${r.message}") }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormDialog.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormDialog.kt
@@ -1,0 +1,47 @@
+package dev.pandesal.sbp.presentation.reminders
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import java.time.LocalDate
+
+@Composable
+fun ReminderFormDialog(
+    date: LocalDate,
+    onDismiss: () -> Unit,
+    reminderId: String? = null,
+    viewModel: ReminderFormViewModel = hiltViewModel()
+) {
+    val state by viewModel.uiState.collectAsState()
+    var text by remember { mutableStateOf("") }
+
+    when (state) {
+        is ReminderFormUiState.Initial -> viewModel.load(null)
+        is ReminderFormUiState.Ready -> text = (state as ReminderFormUiState.Ready).text
+        else -> {}
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(onClick = { viewModel.save(date, text, reminderId) { onDismiss() } }) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+        text = {
+            TextField(value = text, onValueChange = { text = it }, label = { Text("Reminder") })
+        }
+    )
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormUiState.kt
@@ -1,0 +1,8 @@
+package dev.pandesal.sbp.presentation.reminders
+
+sealed interface ReminderFormUiState {
+    data object Initial : ReminderFormUiState
+    data object Loading : ReminderFormUiState
+    data class Ready(val text: String) : ReminderFormUiState
+    data class Error(val message: String) : ReminderFormUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/ReminderFormViewModel.kt
@@ -1,0 +1,34 @@
+package dev.pandesal.sbp.presentation.reminders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.Reminder
+import dev.pandesal.sbp.domain.usecase.ReminderUseCase
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class ReminderFormViewModel @Inject constructor(
+    private val useCase: ReminderUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ReminderFormUiState>(ReminderFormUiState.Initial)
+    val uiState: StateFlow<ReminderFormUiState> = _uiState.asStateFlow()
+
+    fun load(reminder: Reminder?) {
+        _uiState.value = ReminderFormUiState.Ready(reminder?.message ?: "")
+    }
+
+    fun save(date: LocalDate, text: String, id: String? = null, onDone: () -> Unit) {
+        viewModelScope.launch {
+            val reminder = Reminder(id = id ?: java.util.UUID.randomUUID().toString(), date = date, message = text)
+            useCase.upsertReminder(reminder)
+            onDone()
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=49
+versionMinor=50
 versionPatch=1


### PR DESCRIPTION
## Summary
- enable interactive calendar days
- add reminder model and data layer
- load daily transactions, recurring items, and reminders
- show expressive tooltip for date details
- create reminder dialog to add entries
- bump version to 0.50.0

## Testing
- `./gradlew --quiet tasks` *(fails: could not download dependencies)*