### PR TITLE
Add daily spend popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.52.0] - 2025-05-22
+### Added
+- feat: Show contextual popup when tapping daily spend bar
 ## [0.51.0] - 2025-05-22
 ### Added
 - feat: Show tooltip with daily details and reminders on calendar dates

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/DayPopupUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/DayPopupUiState.kt
@@ -1,0 +1,15 @@
+package dev.pandesal.sbp.presentation.home
+
+import dev.pandesal.sbp.domain.model.Transaction
+import java.math.BigDecimal
+
+sealed interface DayPopupUiState {
+    data object Loading : DayPopupUiState
+    data class Ready(
+        val inflow: BigDecimal,
+        val outflow: BigDecimal,
+        val budgetChange: BigDecimal,
+        val transactions: List<Transaction>
+    ) : DayPopupUiState
+    data class Error(val message: String) : DayPopupUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/HomeScreen.kt
@@ -42,6 +42,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.window.Popup
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -63,6 +66,8 @@ import dev.pandesal.sbp.presentation.components.SkeletonLoader
 import dev.pandesal.sbp.presentation.components.TransactionItem
 import dev.pandesal.sbp.presentation.home.components.AccountCard
 import dev.pandesal.sbp.presentation.home.components.DailySpendBarChart
+import dev.pandesal.sbp.presentation.home.components.DailySpendPopup
+import dev.pandesal.sbp.presentation.home.DayPopupUiState
 import dev.pandesal.sbp.presentation.model.AccountSummaryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetCategoryUiModel
 import dev.pandesal.sbp.presentation.model.BudgetSummaryUiModel
@@ -89,6 +94,9 @@ fun HomeScreen(
     val transactionsState by transactionsViewModel.uiState.collectAsState()
     val refreshing = homeState is HomeUiState.Loading || transactionsState is TransactionsUiState.Loading
     val pullRefreshState = rememberPullToRefreshState()
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    var popupOffset by remember { mutableStateOf(IntOffset.Zero) }
+    val popupState by viewModel.popupState.collectAsState()
 
 
     PullToRefreshBox(
@@ -114,8 +122,25 @@ fun HomeScreen(
                             NavigationDestination.NewTransaction(tx)
                         )
                     },
-                    onViewNotifications = { navController.navigate(NavigationDestination.Notifications) }
+                    onViewNotifications = { navController.navigate(NavigationDestination.Notifications) },
+                    onBarClicked = { index, offset ->
+                        val date = LocalDate.now().minusDays((state.dailySpent.entries.size - 1 - index).toLong())
+                        selectedDate = date
+                        popupOffset = offset
+                        viewModel.loadDayDetails(date)
+                    }
                 )
+            }
+        }
+        selectedDate?.let { date ->
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.5f))
+                    .clickable { selectedDate = null }
+            )
+            Popup(alignment = Alignment.TopStart, offset = popupOffset) {
+                DailySpendPopup(date = date, state = popupState)
             }
         }
     }
@@ -126,7 +151,8 @@ private fun HomeScreenContent(
     state: HomeUiState.Success,
     transactions: List<Transaction>,
     onTransactionClicked: (Transaction) -> Unit,
-    onViewNotifications: () -> Unit
+    onViewNotifications: () -> Unit,
+    onBarClicked: (Int, IntOffset) -> Unit
 ) {
     val totalAmount = state.accounts.sumOf { it.balance }
     val totalAllocated = state.favoriteBudgets.sumOf { it.allocated }
@@ -239,9 +265,13 @@ private fun HeaderSection(
                 AccountSummarySection(totalAmount, currency)
                 HomeToolbar(onViewNotifications)
             }
-            DailySpendBarChart(dailySpendUiModel = dailySpent, modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .fillMaxWidth())
+            DailySpendBarChart(
+                dailySpendUiModel = dailySpent,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .fillMaxWidth(),
+                onBarClick = onBarClicked
+            )
             Spacer(modifier = Modifier.height(16.dp))
         }
     }
@@ -452,7 +482,8 @@ fun HomeScreenPreview() {
                 )
             ),
             onTransactionClicked = { _ -> },
-            onViewNotifications = {}
+            onViewNotifications = {},
+            onBarClicked = { _, _ -> }
         )
     }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendBarChart.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -26,6 +27,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.positionInRoot
 import dev.pandesal.sbp.presentation.model.DailySpend
 import dev.pandesal.sbp.presentation.model.DailySpendUiModel
 import dev.pandesal.sbp.presentation.theme.StopBeingPoorTheme
@@ -37,7 +44,8 @@ fun DailySpendBarChart(
     dailySpendUiModel: DailySpendUiModel,
     modifier: Modifier = Modifier,
     barWidth: Dp = 64.dp,
-    chartHeight: Dp = 200.dp
+    chartHeight: Dp = 200.dp,
+    onBarClick: (Int, IntOffset) -> Unit = { _, _ -> }
 ) {
     val primary = Color(0xFF4BE263)// MaterialTheme.colorScheme.primary
     val secondary = Color(0xFF4BE263) //MaterialTheme.colorScheme.secondary
@@ -60,10 +68,21 @@ fun DailySpendBarChart(
         )
         Spacer(modifier = Modifier.height(16.dp))
 
+        var rowCoords: LayoutCoordinates? = null
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(chartHeight),
+                .height(chartHeight)
+                .onGloballyPositioned { rowCoords = it }
+                .pointerInput(dailySpendUiModel.entries) {
+                    detectTapGestures { offset ->
+                        val index = (offset.x / (size.width / dailySpendUiModel.entries.size)).toInt()
+                        if (index in dailySpendUiModel.entries.indices) {
+                            val global = (rowCoords?.positionInRoot() ?: Offset.Zero) + offset
+                            onBarClick(index, IntOffset(global.x.toInt(), global.y.toInt()))
+                        }
+                    }
+                },
             verticalAlignment = Alignment.Bottom,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendPopup.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/home/components/DailySpendPopup.kt
@@ -1,0 +1,61 @@
+package dev.pandesal.sbp.presentation.home.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.pandesal.sbp.presentation.components.TransactionItem
+import dev.pandesal.sbp.presentation.home.DayPopupUiState
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun DailySpendPopup(
+    date: LocalDate,
+    state: DayPopupUiState,
+    modifier: Modifier = Modifier
+) {
+    AnimatedVisibility(
+        visible = state is DayPopupUiState.Ready,
+        enter = fadeIn() + scaleIn(),
+        exit = fadeOut() + scaleOut(),
+        modifier = modifier
+    ) {
+        val ready = state as DayPopupUiState.Ready
+        Card(
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            Column(modifier = Modifier.padding(16.dp), horizontalAlignment = Alignment.Start) {
+                Text(
+                    text = date.format(DateTimeFormatter.ofPattern("MMM d, yyyy")),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Spacer(modifier = Modifier.padding(top = 4.dp))
+                Text("Inflow: ${ready.inflow}", style = MaterialTheme.typography.bodySmall)
+                Text("Outflow: ${ready.outflow}", style = MaterialTheme.typography.bodySmall)
+                Text("Budget changes: ${ready.budgetChange}", style = MaterialTheme.typography.bodySmall)
+                ready.transactions.takeIf { it.isNotEmpty() }?.let { txs ->
+                    Spacer(modifier = Modifier.padding(top = 8.dp))
+                    Text("Transactions", style = MaterialTheme.typography.titleMedium)
+                    txs.forEach { tx ->
+                        TransactionItem(tx)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=51
+versionMinor=52
 versionPatch=0


### PR DESCRIPTION
## Summary
- show contextual popup when a bar in the daily spend chart is tapped
- compute inflow/outflow totals for the day and display in popup
- wire up bar click handling in chart and home screen
- bump version to 0.52.0

## Testing
- `./gradlew test --quiet` *(fails: No route to host)*
- `./gradlew assembleDebug -q` *(fails: No route to host)*