### PR TITLE
Fix bottom sheet reopen issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.51.1] - 2025-05-22
+### Fixed
+- fix: Always open transaction details when an account is tapped
+
 ## [0.51.0] - 2025-05-22
 ### Added
 - feat: Show tooltip with daily details and reminders on calendar dates

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -82,6 +82,7 @@ fun AccountsScreen(
     val navigationManager = LocalNavigationManager.current
 
     var selectedAccount by remember { mutableStateOf<dev.pandesal.sbp.domain.model.Account?>(null) }
+    var sheetTrigger by remember { mutableStateOf(0L) }
     var showRename by remember { mutableStateOf(false) }
     var showDelete by remember { mutableStateOf(false) }
     var showAdjust by remember { mutableStateOf(false) }
@@ -94,7 +95,7 @@ fun AccountsScreen(
         isIconExpanded = scaffoldState.bottomSheetState.targetValue == SheetValue.Expanded
     }
 
-    LaunchedEffect(selectedAccount) {
+    LaunchedEffect(sheetTrigger) {
         selectedAccount?.let {
             txViewModel.load(it.id.toString())
             scope.launch { scaffoldState.bottomSheetState.expand() }
@@ -238,7 +239,10 @@ fun AccountsScreen(
                     AccountsContent(
                         accounts = state.accounts,
                         onAddWallet = { navigationManager.navigate(NavigationDestination.NewAccount) },
-                        onAccountClick = { selectedAccount = it },
+                        onAccountClick = {
+                            selectedAccount = it
+                            sheetTrigger = System.currentTimeMillis()
+                        },
                         modifier = Modifier.padding(padding)
                     )
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ android.nonTransitiveRClass=true
 
 versionMajor=0
 versionMinor=51
-versionPatch=0
+versionPatch=1


### PR DESCRIPTION
## Summary
- always trigger bottom sheet when an account is tapped
- bump version to 0.51.1

## Testing
- `./gradlew test --quiet` *(fails: No route to host)*