### PR TITLE
feat: redesign notification center with card layout and sticky date headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.52.0] - 2025-05-22
+### Added
+- feat: Redesign notification center with card layout and sticky headers
 ## [0.51.0] - 2025-05-22
 ### Added
 - feat: Show tooltip with daily details and reminders on calendar dates

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/Notification.kt
@@ -3,6 +3,7 @@ package dev.pandesal.sbp.domain.model
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
 import java.util.UUID
 
 enum class NotificationType {
@@ -18,5 +19,6 @@ data class Notification(
     val message: String,
     val type: NotificationType = NotificationType.GENERAL,
     val isRead: Boolean = false,
-    val canCreateTransaction: Boolean = false
+    val canCreateTransaction: Boolean = false,
+    val timestamp: LocalDateTime = LocalDateTime.now()
 ) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/RecurringTransactionUseCase.kt
@@ -31,7 +31,8 @@ class RecurringTransactionUseCase @Inject constructor(
                 if (!next.isAfter(endDate)) {
                     Notification(
                         message = "${rec.transaction.name} due on $next",
-                        type = NotificationType.BILL_REMINDER
+                        type = NotificationType.BILL_REMINDER,
+                        timestamp = next.atStartOfDay()
                     )
                 } else {
                     null

--- a/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
+++ b/app/src/main/java/dev/pandesal/sbp/notification/InAppNotificationCenter.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp.notification
 
 import dev.pandesal.sbp.domain.model.Notification
 import dev.pandesal.sbp.domain.model.NotificationType
+import java.time.LocalDateTime
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,12 +12,14 @@ object InAppNotificationCenter {
         listOf(
             Notification(
                 message = "Electric bill due tomorrow",
-                type = NotificationType.BILL_REMINDER
+                type = NotificationType.BILL_REMINDER,
+                timestamp = LocalDateTime.now()
             ),
             Notification(
                 message = "Did you spend with GCash today?",
                 type = NotificationType.TRANSACTION_SUGGESTION,
-                canCreateTransaction = true
+                canCreateTransaction = true,
+                timestamp = LocalDateTime.now()
             )
         )
     )
@@ -25,13 +28,15 @@ object InAppNotificationCenter {
     fun postNotification(
         message: String,
         type: NotificationType = NotificationType.GENERAL,
-        canCreateTransaction: Boolean = false
+        canCreateTransaction: Boolean = false,
+        timestamp: LocalDateTime = LocalDateTime.now()
     ) {
         _notifications.value =
             _notifications.value + Notification(
                 message = message,
                 type = type,
-                canCreateTransaction = canCreateTransaction
+                canCreateTransaction = canCreateTransaction,
+                timestamp = timestamp
             )
     }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterScreen.kt
@@ -10,15 +10,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.stickyHeader
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Event
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Payments
 import android.Manifest
 import android.content.pm.PackageManager
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryTabRow
+import androidx.compose.material3.Surface
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Tab
@@ -27,6 +34,8 @@ import androidx.compose.material3.TabRowDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
@@ -46,6 +55,8 @@ import dev.pandesal.sbp.domain.model.NotificationType
 import dev.pandesal.sbp.presentation.LocalNavigationManager
 import androidx.hilt.navigation.compose.hiltViewModel
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterViewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -85,6 +96,19 @@ fun NotificationCenterScreen(viewModel: NotificationCenterViewModel = hiltViewMo
         else -> notifications
     }
 
+    val pullRefreshState = rememberPullToRefreshState()
+    val groupedNotifications = filteredNotifications
+        .sortedByDescending { it.timestamp }
+        .groupBy {
+            val date = it.timestamp.toLocalDate()
+            when (date) {
+                LocalDate.now() -> "Today"
+                LocalDate.now().minusDays(1) -> "Yesterday"
+                in LocalDate.now().minusDays(6)..LocalDate.now().minusDays(2) -> "This Week"
+                else -> date.format(DateTimeFormatter.ofPattern("MMM d"))
+            }
+        }
+
     Column(
         modifier = Modifier.fillMaxSize()
     ) {
@@ -116,34 +140,55 @@ fun NotificationCenterScreen(viewModel: NotificationCenterViewModel = hiltViewMo
                 )
             }
         }
-
-        LazyColumn(
-            modifier = Modifier.fillMaxSize()
+        PullToRefreshBox(
+            isRefreshing = false,
+            state = pullRefreshState,
+            onRefresh = { viewModel.refresh() }
         ) {
-            items(filteredNotifications, key = { it.id }) { notif ->
-                val dismissState = rememberSwipeToDismissBoxState(confirmValueChange = {
-                    if (it == SwipeToDismissBoxValue.StartToEnd || it == SwipeToDismissBoxValue.EndToStart) {
-                        InAppNotificationCenter.archive(notif.id)
-                        true
-                    } else {
-                        false
-                    }
-                })
-                SwipeToDismissBox(
-                    state = dismissState,
-                    backgroundContent = {},
-                ) {
-                    NotificationItem(
-                        notification = notif,
-                        onMarkRead = { InAppNotificationCenter.markAsRead(notif.id) },
-                        onCreateTransaction = {
-                            coroutineScope.launch {
-                                val tx = viewModel.parseTransaction(notif.message)
-                                InAppNotificationCenter.markAsRead(notif.id)
-                                navController.navigate(dev.pandesal.sbp.presentation.NavigationDestination.NewTransaction(tx))
-                            }
+            LazyColumn(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                if (filteredNotifications.isEmpty()) {
+                    item { EmptyState() }
+                }
+                groupedNotifications.forEach { (label, list) ->
+                    stickyHeader {
+                        Surface(color = MaterialTheme.colorScheme.surface) {
+                            Text(
+                                text = label,
+                                style = MaterialTheme.typography.titleSmall,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                            )
                         }
-                    )
+                    }
+                    items(list, key = { it.id }) { notif ->
+                        val dismissState = rememberSwipeToDismissBoxState(confirmValueChange = {
+                            if (it == SwipeToDismissBoxValue.StartToEnd || it == SwipeToDismissBoxValue.EndToStart) {
+                                InAppNotificationCenter.archive(notif.id)
+                                true
+                            } else {
+                                false
+                            }
+                        })
+                        SwipeToDismissBox(
+                            state = dismissState,
+                            backgroundContent = {},
+                        ) {
+                            NotificationItem(
+                                notification = notif,
+                                onMarkRead = { InAppNotificationCenter.markAsRead(notif.id) },
+                                onCreateTransaction = {
+                                    coroutineScope.launch {
+                                        val tx = viewModel.parseTransaction(notif.message)
+                                        InAppNotificationCenter.markAsRead(notif.id)
+                                        navController.navigate(dev.pandesal.sbp.presentation.NavigationDestination.NewTransaction(tx))
+                                    }
+                                }
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -156,33 +201,76 @@ private fun NotificationItem(
     onMarkRead: () -> Unit,
     onCreateTransaction: () -> Unit
 ) {
-    Column(
+    ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = MaterialTheme.shapes.medium,
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)
     ) {
         Row(
-            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (!notification.isRead) {
-                    Box(
-                        Modifier
-                            .padding(end = 8.dp)
-                            .background(color = MaterialTheme.colorScheme.primary, shape = MaterialTheme.shapes.small)
-                            .padding(4.dp)
-                    ) {}
+                Icon(
+                    imageVector = when (notification.type) {
+                        NotificationType.BILL_REMINDER -> Icons.Outlined.Event
+                        NotificationType.TRANSACTION_SUGGESTION -> Icons.Outlined.Payments
+                        else -> Icons.Outlined.Notifications
+                    },
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+
+                Column(modifier = Modifier.padding(start = 12.dp)) {
+                    Text(
+                        text = when (notification.type) {
+                            NotificationType.BILL_REMINDER -> "Bill Reminder"
+                            NotificationType.TRANSACTION_SUGGESTION -> "Transaction Alert"
+                            else -> "Notification"
+                        },
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    Text(
+                        text = notification.message,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
                 }
-                Text(notification.message)
             }
-            if (notification.canCreateTransaction) {
-                TextButton(onClick = onCreateTransaction) {
-                    Text("Add")
+
+            Column(horizontalAlignment = Alignment.End) {
+                Text(
+                    text = notification.timestamp.format(DateTimeFormatter.ofPattern("MMM d, h:mm a")),
+                    style = MaterialTheme.typography.labelSmall
+                )
+                if (notification.canCreateTransaction) {
+                    TextButton(onClick = onCreateTransaction) { Text("Add") }
                 }
             }
         }
     }
     onMarkRead()
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 64.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Notifications,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        Text(text = "You're all caught up!", style = MaterialTheme.typography.bodyMedium)
+    }
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/notifications/NotificationCenterViewModel.kt
@@ -40,5 +40,8 @@ class NotificationCenterViewModel @Inject constructor(
         viewModelScope.launch { settingsUseCase.setNotificationsEnabled(enabled) }
     }
 
+    fun refresh() {
+    }
+
     suspend fun parseTransaction(text: String): Transaction = geminiService.parseSms(text)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=51
+versionMinor=52
 versionPatch=0


### PR DESCRIPTION
## Summary
- redesign notification center with card layout and sticky date headers
- bump version to 0.52.0
- tidy refresh function

## Testing
- `./gradlew assembleDebug -x lint` *(fails: No route to host)*