### PR TITLE
Add recurring calendar events per month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.56.0] - 2025-05-23
+### Added
+- feat: Load recurring transactions when navigating calendar months
 ## [0.55.0] - 2025-05-23
 ### Added
 - feat: Include calendar reminders in upcoming notifications

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -84,7 +84,10 @@ fun InsightsScreen(
                     events = monthEvents,
                     month = calendarMonth,
                     selectedDate = selectedDate,
-                    onMonthChange = { calendarMonth = it },
+                    onMonthChange = {
+                        calendarMonth = it
+                        viewModel.setCalendarMonth(it)
+                    },
                     onDateClick = { date, offset ->
                         selectedDate = date
                         tooltipOffset = offset

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/components/CalendarView.kt
@@ -169,8 +169,10 @@ fun CalendarView(
     }
 }
 
+@Composable
 private fun colorFor(type: CalendarEventType): Color = when (type) {
     CalendarEventType.INFLOW -> Color(0xFF2E7D32)
     CalendarEventType.OUTFLOW -> Color(0xFFC62828)
     CalendarEventType.BILL -> Color.Gray
+    CalendarEventType.RECURRING -> MaterialTheme.colorScheme.tertiary
 }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/model/CalendarEvent.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/model/CalendarEvent.kt
@@ -5,7 +5,8 @@ import java.time.LocalDate
 enum class CalendarEventType {
     INFLOW,
     OUTFLOW,
-    BILL
+    BILL,
+    RECURRING
 }
 
 data class CalendarEvent(

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=55
+versionMinor=56
 versionPatch=0


### PR DESCRIPTION
## Summary
- compute recurring events for calendar months
- add calendar month state in `InsightsViewModel`
- load recurring occurrences when changing months
- support RECURRING calendar event type
- bump version to 0.56.0

## Testing
- `./gradlew test` *(fails: No route to host)*