### PR TITLE
Add reminders screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.57.0] - 2025-05-23
+### Added
+- feat: Show reminders screen with combined upcoming items
 ## [0.56.0] - 2025-05-23
 ### Added
 - feat: Load recurring transactions when navigating calendar months

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/UpcomingReminder.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/UpcomingReminder.kt
@@ -1,0 +1,16 @@
+package dev.pandesal.sbp.domain.model
+
+import java.math.BigDecimal
+import java.time.LocalDate
+
+/** Combined reminder model for one-time reminders and recurring transactions */
+data class UpcomingReminder(
+    val id: String,
+    val title: String,
+    val dueDate: LocalDate,
+    val interval: RecurringInterval? = null,
+    val amount: BigDecimal? = null,
+    val category: Category? = null
+) {
+    val isRecurring: Boolean get() = interval != null
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -28,6 +28,7 @@ import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import dev.pandesal.sbp.presentation.goals.NewGoalScreen
 import dev.pandesal.sbp.presentation.nav.parcelableTypeMap
+import dev.pandesal.sbp.presentation.reminders.RemindersScreen
 import java.math.BigDecimal
 import kotlinx.serialization.Serializable
 import kotlin.reflect.typeOf
@@ -50,6 +51,8 @@ sealed class NavigationDestination() {
     data class NewTransaction(val transaction: Transaction? = null) : NavigationDestination()
     @Serializable
     data object Notifications : NavigationDestination()
+    @Serializable
+    data object Reminders : NavigationDestination()
     @Serializable
     data object Accounts : NavigationDestination()
     @Serializable
@@ -92,6 +95,9 @@ fun AppNavigation(navController: NavHostController) {
             }
             composable<NavigationDestination.Categories> {
                 CategoriesScreen()
+            }
+            composable<NavigationDestination.Reminders> {
+                RemindersScreen()
             }
             composable<NavigationDestination.Accounts> {
                 AccountsScreen()

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -32,7 +32,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PieChart
-import androidx.compose.material.icons.filled.AccountBalanceWallet
+import androidx.compose.material.icons.filled.Event
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -244,7 +244,7 @@ class MainActivity : ComponentActivity() {
                                 }
 
                                 IconButton(onClick = {
-                                    navController.navigate(NavigationDestination.Accounts) {
+                                    navController.navigate(NavigationDestination.Reminders) {
                                         popUpTo(navController.graph.findStartDestination().id) {
                                             saveState = true
                                         }
@@ -253,8 +253,8 @@ class MainActivity : ComponentActivity() {
                                     }
                                 }) {
                                     Icon(
-                                        Icons.Filled.AccountBalanceWallet,
-                                        contentDescription = "Localized description"
+                                        Icons.Filled.Event,
+                                        contentDescription = "Reminders"
                                     )
                                 }
 

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersScreen.kt
@@ -1,0 +1,201 @@
+package dev.pandesal.sbp.presentation.reminders
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Event
+import androidx.compose.material.icons.outlined.Repeat
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.domain.model.RecurringInterval
+import dev.pandesal.sbp.domain.model.UpcomingReminder
+import dev.pandesal.sbp.presentation.components.SkeletonLoader
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun RemindersScreen(viewModel: RemindersViewModel = hiltViewModel()) {
+    val state by viewModel.uiState.collectAsState()
+    var selected by remember { mutableStateOf<UpcomingReminder?>(null) }
+
+    when (state) {
+        is RemindersUiState.Loading -> SkeletonLoader()
+        is RemindersUiState.Success -> {
+            val reminders = (state as RemindersUiState.Success).reminders
+            RemindersContent(reminders) { selected = it }
+        }
+        is RemindersUiState.Error -> Text("Error")
+    }
+
+    selected?.let { item ->
+        ReminderOptionsDialog(
+            item = item,
+            onDismiss = { selected = null },
+            onMarkDone = {
+                viewModel.markDone(it)
+                selected = null
+            },
+            onEdit = { /*TODO*/ },
+            onConvert = { /*TODO*/ }
+        )
+    }
+}
+
+@Composable
+private fun RemindersContent(reminders: List<UpcomingReminder>, onItemClick: (UpcomingReminder) -> Unit) {
+    if (reminders.isEmpty()) {
+        EmptyState()
+    } else {
+        LazyColumn(modifier = Modifier.fillMaxSize()) {
+            items(reminders, key = { it.id }) { item ->
+                ReminderCard(item, onClick = { onItemClick(item) })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReminderCard(item: UpcomingReminder, onClick: () -> Unit) {
+    ElevatedCard(
+        onClick = onClick,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = if (item.isRecurring) Icons.Outlined.Repeat else Icons.Outlined.Event,
+                    contentDescription = null,
+                    tint = if (item.isRecurring) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary
+                )
+                Column(modifier = Modifier.padding(start = 12.dp)) {
+                    Text(item.title, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                    Text(
+                        text = item.dueDate.format(DateTimeFormatter.ofPattern("MMM d")),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    item.interval?.let { interval ->
+                        Text(
+                            text = intervalLabel(interval),
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier
+                                .padding(top = 4.dp)
+                                .align(Alignment.Start),
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+            item.amount?.let { amt ->
+                Text(
+                    text = "₱" + amt.toString(),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}
+
+private fun intervalLabel(interval: RecurringInterval): String = when (interval) {
+    RecurringInterval.DAILY -> "Daily"
+    RecurringInterval.WEEKLY -> "Weekly"
+    RecurringInterval.MONTHLY -> "Monthly"
+    RecurringInterval.AFTER_CUTOFF -> "Monthly"
+    RecurringInterval.QUARTERLY -> "Quarterly"
+    RecurringInterval.HALF_YEARLY -> "Every 6 Months"
+    RecurringInterval.YEARLY -> "Yearly"
+}
+
+@Composable
+private fun ReminderOptionsDialog(
+    item: UpcomingReminder,
+    onDismiss: () -> Unit,
+    onMarkDone: (UpcomingReminder) -> Unit,
+    onEdit: (UpcomingReminder) -> Unit,
+    onConvert: (UpcomingReminder) -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Column {
+                Button(onClick = { onMarkDone(item) }) { Text("Mark Done") }
+                Button(onClick = { onEdit(item) }) { Text("Edit") }
+                Button(onClick = { onConvert(item) }) { Text("Convert") }
+                if (item.isRecurring) {
+                    TextButton(onClick = onDismiss) { Text("Skip This") }
+                }
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Close") } },
+        title = { Text(item.title) }
+    )
+}
+
+@Composable
+private fun EmptyState() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(top = 64.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Event,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+        Text("You're all caught up! No upcoming reminders.", style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Preview
+@Composable
+private fun ReminderCardPreview() {
+    val item = UpcomingReminder(
+        id = "1",
+        title = "Electric Bill",
+        dueDate = LocalDate.now().plusDays(2),
+        interval = RecurringInterval.MONTHLY,
+        amount = BigDecimal("1200")
+    )
+    ReminderCard(item = item, onClick = {})
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersUiState.kt
@@ -1,0 +1,9 @@
+package dev.pandesal.sbp.presentation.reminders
+
+import dev.pandesal.sbp.domain.model.UpcomingReminder
+
+sealed interface RemindersUiState {
+    data object Loading : RemindersUiState
+    data class Success(val reminders: List<UpcomingReminder>) : RemindersUiState
+    data class Error(val message: String) : RemindersUiState
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/reminders/RemindersViewModel.kt
@@ -1,0 +1,47 @@
+package dev.pandesal.sbp.presentation.reminders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.pandesal.sbp.domain.model.UpcomingReminder
+import dev.pandesal.sbp.domain.usecase.RecurringTransactionUseCase
+import dev.pandesal.sbp.domain.usecase.ReminderUseCase
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+@HiltViewModel
+class RemindersViewModel @Inject constructor(
+    private val recurringUseCase: RecurringTransactionUseCase,
+    private val reminderUseCase: ReminderUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<RemindersUiState>(RemindersUiState.Loading)
+    val uiState: StateFlow<RemindersUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            recurringUseCase.getUpcomingReminders(LocalDate.now()).collect { list ->
+                _uiState.value = RemindersUiState.Success(list)
+            }
+        }
+    }
+
+    fun markDone(item: UpcomingReminder) {
+        if (!item.isRecurring) {
+            viewModelScope.launch {
+                reminderUseCase.deleteReminder(
+                    dev.pandesal.sbp.domain.model.Reminder(
+                        id = item.id,
+                        date = item.dueDate,
+                        message = item.title,
+                        shouldNotify = false
+                    )
+                )
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=56
+versionMinor=57
 versionPatch=0


### PR DESCRIPTION
## Summary
- show unified reminders list of one-time reminders and recurring transactions
- route to Reminders screen via AppNavigation
- replace Accounts tab with Reminders in main nav
- bump version to 0.57.0

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*