### PR TITLE
Add hobby tagging to transactions and insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.58.0] - 2025-05-24
+### Added
+- feat: Allow tagging transactions with hobbies
+- feat: Display top hobby spending in Insights
 ## [0.57.0] - 2025-05-24
 ### Added
 - feat: Enable save button only when required fields are filled

--- a/app/src/main/java/dev/pandesal/sbp/domain/model/TagSummary.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/model/TagSummary.kt
@@ -1,0 +1,11 @@
+package dev.pandesal.sbp.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import java.math.BigDecimal
+
+@Parcelize
+data class TagSummary(
+    val tag: String,
+    val total: BigDecimal
+) : Parcelable

--- a/app/src/main/java/dev/pandesal/sbp/domain/repository/TransactionRepositoryInterface.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/repository/TransactionRepositoryInterface.kt
@@ -5,6 +5,7 @@ import dev.pandesal.sbp.domain.model.CategoryGroup
 import dev.pandesal.sbp.domain.model.MonthlyBudget
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.model.TagSummary
 import kotlinx.coroutines.flow.Flow
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -28,6 +29,8 @@ interface TransactionRepositoryInterface {
     fun getPagedTransactionsByCategory(categoryId: String, limit: Int, offset: Int): Flow<List<Transaction>>
     fun getTotalAmountByCategory(type: TransactionType): Flow<List<Pair<Int, BigDecimal>>>
     fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>>
+    fun getTags(): Flow<List<String>>
+    fun getTotalAmountByTag(type: TransactionType): Flow<List<TagSummary>>
     suspend fun getLastMerchantForCategory(categoryId: String): String?
     suspend fun insert(transaction: Transaction)
     suspend fun delete(transaction: Transaction)

--- a/app/src/main/java/dev/pandesal/sbp/domain/usecase/TransactionUseCase.kt
+++ b/app/src/main/java/dev/pandesal/sbp/domain/usecase/TransactionUseCase.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp.domain.usecase
 
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.model.TagSummary
 import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
 import dev.pandesal.sbp.domain.repository.AccountRepositoryInterface
 import kotlinx.coroutines.flow.Flow
@@ -64,6 +65,11 @@ class TransactionUseCase @Inject constructor(
 
     fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>> =
         repository.getMerchantsByCategoryId(categoryId)
+
+    fun getTags(): Flow<List<String>> = repository.getTags()
+
+    fun getTotalAmountByTag(type: TransactionType): Flow<List<TagSummary>> =
+        repository.getTotalAmountByTag(type)
 
     suspend fun getLastMerchantForCategory(categoryId: String): String? =
         repository.getLastMerchantForCategory(categoryId)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsScreen.kt
@@ -127,6 +127,14 @@ fun InsightsScreen(
                 )
             }
 
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val tagSummary by viewModel.tagSummary.collectAsState()
+            Text("Top 5 Hobbies you spend on", style = MaterialTheme.typography.titleMedium)
+            tagSummary.take(5).forEach { summary ->
+                Text("${summary.tag}: ${summary.total}", style = MaterialTheme.typography.bodyMedium)
+            }
+
                 if (trendState is TrendsUiState.Ready) {
                     Spacer(modifier = Modifier.height(16.dp))
                     val trendData =

--- a/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/insights/InsightsViewModel.kt
@@ -20,6 +20,7 @@ import dev.pandesal.sbp.presentation.model.CashflowUiModel
 import dev.pandesal.sbp.presentation.model.CalendarEvent
 import dev.pandesal.sbp.presentation.model.CalendarEventType
 import dev.pandesal.sbp.presentation.model.NetWorthUiModel
+import dev.pandesal.sbp.domain.model.TagSummary
 import dev.pandesal.sbp.presentation.insights.TimePeriod
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -53,8 +54,16 @@ class InsightsViewModel @Inject constructor(
     private val _calendarMonth = MutableStateFlow(YearMonth.now())
     val calendarMonth: StateFlow<YearMonth> = _calendarMonth.asStateFlow()
 
+    private val _tagSummary = MutableStateFlow<List<TagSummary>>(emptyList())
+    val tagSummary: StateFlow<List<TagSummary>> = _tagSummary.asStateFlow()
+
     init {
         observeData()
+        viewModelScope.launch {
+            transactionUseCase.getTotalAmountByTag(TransactionType.OUTFLOW).collect {
+                _tagSummary.value = it
+            }
+        }
     }
 
     fun setPeriod(period: TimePeriod) {

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.twotone.ArrowDropDown
 import androidx.compose.material.icons.twotone.DateRange
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Wallet
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -56,6 +57,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.rememberDatePickerState
+import com.google.accompanist.flowlayout.FlowRow
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
@@ -135,6 +137,7 @@ fun NewTransactionScreen(
             accounts = state.accounts,
             transaction = state.transaction,
             merchants = state.merchants,
+            tags = state.tags,
             errors = state.errors,
             editable = editable,
             onEdit = { editable = true },
@@ -184,6 +187,7 @@ private fun NewTransactionScreen(
     accounts: List<Account>,
     transaction: Transaction,
     merchants: List<String>,
+    tags: List<String>,
     errors: NewTransactionUiState.ValidationErrors,
     editable: Boolean,
     onEdit: () -> Unit,
@@ -231,6 +235,7 @@ private fun NewTransactionScreen(
 
     var expanded by remember { mutableStateOf(false) }
     var merchantExpanded by remember { mutableStateOf(false) }
+    var tagExpanded by remember { mutableStateOf(false) }
     var fromAccountExpanded by remember { mutableStateOf(false) }
     var toAccountExpanded by remember { mutableStateOf(false) }
     var isRecurring by remember { mutableStateOf(false) }
@@ -737,7 +742,75 @@ private fun NewTransactionScreen(
                             }
                         }
 
+                        // Tags section
+                        Column(modifier = Modifier.padding(top = 16.dp)) {
+                            var newTag by remember { mutableStateOf("") }
+                            Text("Track to Hobby/Activity (optional)", style = MaterialTheme.typography.bodyMedium)
+                            ElevatedCard(
+                                modifier = Modifier
+                                    .padding(top = 4.dp)
+                                    .fillMaxWidth()
+                            ) {
+                                FlowRow(
+                                    modifier = Modifier
+                                        .padding(8.dp)
+                                        .fillMaxWidth(),
+                                    mainAxisSpacing = 4.dp,
+                                    crossAxisSpacing = 4.dp
+                                ) {
+                                    transaction.tags.forEach { tag ->
+                                        AssistChip(
+                                            onClick = {},
+                                            label = { Text(tag) },
+                                            trailingIcon = {
+                                                Icon(
+                                                    Icons.Default.Close,
+                                                    contentDescription = null,
+                                                    modifier = Modifier
+                                                        .size(18.dp)
+                                                        .clickable(enabled = editable) {
+                                                            onUpdate(transaction.copy(tags = transaction.tags - tag))
+                                                        }
+                                                )
+                                            }
+                                        )
+                                    }
+                                    BasicTextField(
+                                        value = newTag,
+                                        onValueChange = { newTag = it },
+                                        modifier = Modifier
+                                            .widthIn(min = 40.dp)
+                                            .clickable { tagExpanded = true }
+                                    )
+                                    IconButton(enabled = editable, onClick = {
+                                        if (newTag.isNotBlank()) {
+                                            onUpdate(transaction.copy(tags = (transaction.tags + newTag).distinct()))
+                                            newTag = ""
+                                        }
+                                    }) {
+                                    Icon(Icons.Default.Check, contentDescription = null)
+                                    }
+                                }
+                            }
+                        }
 
+                        if (tagExpanded) {
+                            ModalBottomSheet(onDismissRequest = { tagExpanded = false }) {
+                                LazyColumn {
+                                    items(tags) { item ->
+                                        Text(
+                                            text = item,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clickable { newTag = item; tagExpanded = false }
+                                                .padding(16.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        Column(modifier = Modifier.padding(top = 16.dp)) {
 
                         Column(modifier = Modifier.padding(top = 16.dp)) {
                             Text("Receipt Photo (optional)", style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionsViewModel.kt
@@ -42,6 +42,8 @@ class NewTransactionsViewModel @Inject constructor(
     private val _merchants = MutableStateFlow<List<String>>(emptyList())
     private var merchantJob: kotlinx.coroutines.Job? = null
 
+    private val _tags = MutableStateFlow<List<String>>(emptyList())
+
     private val _validationErrors: MutableStateFlow<NewTransactionUiState.ValidationErrors> =
         MutableStateFlow(NewTransactionUiState.ValidationErrors())
 
@@ -62,6 +64,7 @@ class NewTransactionsViewModel @Inject constructor(
 
     init {
         subscribeUiState()
+        loadTags()
     }
 
     private fun subscribeUiState() {
@@ -74,11 +77,16 @@ class NewTransactionsViewModel @Inject constructor(
                 accountUseCase.getAccounts(),
                 _transaction,
                 _merchants,
-            ) { groups, categories, accounts, transaction, merchants ->
+                _tags,
+            ) { groups, categories, accounts, transaction, merchants, tags ->
                 NewTransactionUiState.Success(
                     groupedCategories = groups.associateWith { group ->
                         categories.filter { it.categoryGroupId == group.id }
-                    }, accounts = accounts, transaction = transaction, merchants = merchants
+                    },
+                    accounts = accounts,
+                    transaction = transaction,
+                    merchants = merchants,
+                    tags = tags
                 )
             }.zip(
                     _validationErrors
@@ -102,10 +110,19 @@ class NewTransactionsViewModel @Inject constructor(
                     if (current is NewTransactionUiState.Success) {
                         _uiState.value = current.copy(
                             merchants = merchants,
+                            tags = _tags.value,
                             errors = _validationErrors.value,
                         )
                     }
                 }
+        }
+    }
+
+    private fun loadTags() {
+        viewModelScope.launch {
+            transactionUseCase.getTags().collect { list ->
+                _tags.value = list
+            }
         }
     }
 
@@ -201,6 +218,7 @@ class NewTransactionsViewModel @Inject constructor(
             accounts = (_uiState.value as? NewTransactionUiState.Success)?.accounts ?: listOf(),
             transaction = newTransaction,
             merchants = _merchants.value,
+            tags = _tags.value,
             errors = _validationErrors.value,
         )
     }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/TransactionsUiState.kt
@@ -21,6 +21,7 @@ sealed interface NewTransactionUiState {
         val accounts: List<Account>,
         val transaction: Transaction,
         val merchants: List<String>,
+        val tags: List<String>,
         val errors: ValidationErrors = ValidationErrors(),
     ) : NewTransactionUiState
 

--- a/app/src/test/java/dev/pandesal/sbp/fakes/FakeTransactionRepository.kt
+++ b/app/src/test/java/dev/pandesal/sbp/fakes/FakeTransactionRepository.kt
@@ -2,6 +2,7 @@ package dev.pandesal.sbp.fakes
 
 import dev.pandesal.sbp.domain.model.Transaction
 import dev.pandesal.sbp.domain.model.TransactionType
+import dev.pandesal.sbp.domain.model.TagSummary
 import dev.pandesal.sbp.domain.repository.TransactionRepositoryInterface
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,6 +15,7 @@ class FakeTransactionRepository : TransactionRepositoryInterface {
     val pagedFlow = MutableStateFlow<List<Transaction>>(emptyList())
     val categoryFlow = MutableStateFlow<List<Transaction>>(emptyList())
     val merchantsFlow = MutableStateFlow<List<String>>(emptyList())
+    val tagsFlow = MutableStateFlow<List<String>>(emptyList())
     val insertedTransactions = mutableListOf<Transaction>()
 
     override fun getAllTransactions(): Flow<List<Transaction>> = transactionsFlow
@@ -33,6 +35,8 @@ class FakeTransactionRepository : TransactionRepositoryInterface {
     override fun getPagedTransactionsByCategory(categoryId: String, limit: Int, offset: Int): Flow<List<Transaction>> = flowOf(emptyList())
     override fun getTotalAmountByCategory(type: TransactionType): Flow<List<Pair<Int, BigDecimal>>> = flowOf(emptyList())
     override fun getMerchantsByCategoryId(categoryId: String): Flow<List<String>> = merchantsFlow
+    override fun getTags(): Flow<List<String>> = tagsFlow
+    override fun getTotalAmountByTag(type: TransactionType): Flow<List<TagSummary>> = flowOf(emptyList())
     override suspend fun getLastMerchantForCategory(categoryId: String): String? = merchantsFlow.value.lastOrNull()
     override suspend fun insert(transaction: Transaction) { insertedTransactions.add(transaction) }
     override suspend fun delete(transaction: Transaction) {}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=57
+versionMinor=58
 versionPatch=0


### PR DESCRIPTION
## Summary
- support hobby tag summaries in `InsightsViewModel`
- expose tag suggestions and editing in `NewTransactionScreen`
- add hobby tag helpers in `TransactionRepository` and `TransactionUseCase`
- bump version to 0.58.0

## Testing
- `./gradlew test` *(fails: No route to host)*