### PR TITLE
Combine accounts and settings into More screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.61.0] - 2025-05-26
+### Added
+- feat: Combine Accounts with Settings into single More screen
+
 ## [0.60.1] - 2025-05-24
 ### Added
 - feat: Provide haptic and jiggle feedback on invalid transaction form

--- a/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/AppNavigation.kt
@@ -10,8 +10,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.dialog
 import androidx.navigation.toRoute
 import dev.pandesal.sbp.presentation.categories.CategoriesScreen
-import dev.pandesal.sbp.presentation.accounts.AccountsScreen
 import dev.pandesal.sbp.presentation.accounts.NewAccountScreen
+import dev.pandesal.sbp.presentation.more.MoreScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryGroupScreen
 import dev.pandesal.sbp.presentation.categories.new.NewCategoryScreen
 import dev.pandesal.sbp.presentation.home.HomeScreen
@@ -24,7 +24,6 @@ import dev.pandesal.sbp.presentation.transactions.recurringdetails.RecurringTran
 import dev.pandesal.sbp.presentation.transactions.recurring.RecurringTransactionsScreen
 import dev.pandesal.sbp.presentation.categories.budget.SetBudgetScreen
 import dev.pandesal.sbp.presentation.categories.CategoryTransactionsScreen
-import dev.pandesal.sbp.presentation.settings.SettingsScreen
 import dev.pandesal.sbp.presentation.notifications.NotificationCenterScreen
 import dev.pandesal.sbp.presentation.goals.NewGoalScreen
 import dev.pandesal.sbp.presentation.nav.parcelableTypeMap
@@ -44,8 +43,6 @@ sealed class NavigationDestination() {
     @Serializable
     data object More : NavigationDestination()
     @Serializable
-    data object Settings : NavigationDestination()
-    @Serializable
     data object Transactions : NavigationDestination()
     @Serializable
     data class NewTransaction(val transaction: Transaction? = null) : NavigationDestination()
@@ -53,8 +50,6 @@ sealed class NavigationDestination() {
     data object Notifications : NavigationDestination()
     @Serializable
     data object Reminders : NavigationDestination()
-    @Serializable
-    data object Accounts : NavigationDestination()
     @Serializable
     data object NewAccount : NavigationDestination()
     @Serializable
@@ -98,9 +93,6 @@ fun AppNavigation(navController: NavHostController) {
             }
             composable<NavigationDestination.Reminders> {
                 RemindersScreen()
-            }
-            composable<NavigationDestination.Accounts> {
-                AccountsScreen()
             }
 
             dialog<NavigationDestination.NewAccount>(
@@ -196,12 +188,7 @@ fun AppNavigation(navController: NavHostController) {
 
 
             composable<NavigationDestination.More> {
-//                MoreScreen()
-                HomeScreen()
-            }
-
-            composable<NavigationDestination.Settings> {
-                SettingsScreen()
+                MoreScreen()
             }
 
         }

--- a/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/MainActivity.kt
@@ -275,7 +275,7 @@ class MainActivity : ComponentActivity() {
                                     )
                                 }
                                 IconButton(onClick = {
-                                    navController.navigate(NavigationDestination.Settings) {
+                                    navController.navigate(NavigationDestination.More) {
                                         popUpTo(navController.graph.findStartDestination().id) {
                                             saveState = true
                                         }
@@ -283,22 +283,7 @@ class MainActivity : ComponentActivity() {
                                         restoreState = true
                                     }
                                 }) {
-                                    Icon(Icons.Filled.MoreVert, contentDescription = "Settings")
-                                }
-
-                                IconButton(onClick = {
-                                    navController.navigate(NavigationDestination.Accounts) {
-                                        popUpTo(navController.graph.findStartDestination().id) {
-                                            saveState = true
-                                        }
-                                        launchSingleTop = true
-                                        restoreState = true
-                                    }
-                                }) {
-                                    Icon(
-                                        Icons.Filled.AccountCircle,
-                                        contentDescription = "Localized description"
-                                    )
+                                    Icon(Icons.Filled.AccountCircle, contentDescription = "More")
                                 }
                             },
                         )

--- a/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/accounts/AccountsScreen.kt
@@ -257,7 +257,7 @@ fun AccountsScreen(
 }
 
 @Composable
-private fun AccountsContent(
+fun AccountsContent(
     accounts: List<dev.pandesal.sbp.domain.model.Account>,
     onAddWallet: () -> Unit,
     onAccountClick: (dev.pandesal.sbp.domain.model.Account) -> Unit,

--- a/app/src/main/java/dev/pandesal/sbp/presentation/more/MoreScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/more/MoreScreen.kt
@@ -1,0 +1,72 @@
+package dev.pandesal.sbp.presentation.more
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import dev.pandesal.sbp.presentation.accounts.AccountsContent
+import dev.pandesal.sbp.presentation.accounts.AccountsUiState
+import dev.pandesal.sbp.presentation.accounts.AccountsViewModel
+import dev.pandesal.sbp.presentation.LocalNavigationManager
+import dev.pandesal.sbp.presentation.NavigationDestination
+import dev.pandesal.sbp.presentation.settings.SettingsContent
+import dev.pandesal.sbp.presentation.settings.SettingsViewModel
+
+@Composable
+fun MoreScreen(
+    accountsViewModel: AccountsViewModel = hiltViewModel(),
+    settingsViewModel: SettingsViewModel = hiltViewModel(),
+) {
+    val accountsState by accountsViewModel.uiState.collectAsState()
+    val settings by settingsViewModel.settings.collectAsState()
+    val nav = LocalNavigationManager.current
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        when (val state = accountsState) {
+            is AccountsUiState.Loading ->
+                Text("Loading...", modifier = Modifier.padding(16.dp))
+            is AccountsUiState.Error ->
+                Text(state.message, color = MaterialTheme.colorScheme.error)
+            is AccountsUiState.Success -> {
+                Text(
+                    text = "Accounts",
+                    modifier = Modifier.padding(16.dp),
+                    style = MaterialTheme.typography.titleLargeEmphasized
+                )
+                Spacer(Modifier.size(16.dp))
+                AccountsContent(
+                    accounts = state.accounts,
+                    onAddWallet = { nav.navigate(NavigationDestination.NewAccount) },
+                    onAccountClick = {},
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+                Spacer(Modifier.size(24.dp))
+            }
+        }
+        Text(
+            text = "Settings",
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.titleLargeEmphasized
+        )
+        Spacer(Modifier.size(16.dp))
+        SettingsContent(
+            settings = settings,
+            onDarkModeChange = settingsViewModel::setDarkMode,
+            onNotificationsChange = settingsViewModel::setNotificationsEnabled,
+            onDetectFinanceAppUsageChange = settingsViewModel::setDetectFinanceAppUsage,
+            onDetectFinanceApps = settingsViewModel::detectFinanceApps,
+            onCurrencyChange = settingsViewModel::setCurrency,
+            onTravelModeChange = settingsViewModel::setTravelMode,
+            onScanSms = settingsViewModel::scanSms
+        )
+    }
+}

--- a/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/settings/SettingsScreen.kt
@@ -78,7 +78,7 @@ fun SettingsScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun SettingsContent(
+fun SettingsContent(
     settings: dev.pandesal.sbp.domain.model.Settings,
     onDarkModeChange: (Boolean) -> Unit,
     onNotificationsChange: (Boolean) -> Unit,

--- a/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
+++ b/app/src/main/java/dev/pandesal/sbp/presentation/transactions/newtransaction/NewTransactionScreen.kt
@@ -273,12 +273,12 @@ private fun NewTransactionScreen(
         AlertDialog(
             onDismissRequest = {
                 navManager.navigateUp()
-                navManager.navigate(NavigationDestination.Accounts)
+                navManager.navigate(NavigationDestination.More)
             },
             confirmButton = {
                 TextButton(onClick = {
                     navManager.navigateUp()
-                    navManager.navigate(NavigationDestination.Accounts)
+                    navManager.navigate(NavigationDestination.More)
                 }) { Text("Add Account") }
             },
             title = { Text("No Accounts") },

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 
 versionMajor=0
-versionMinor=58
+versionMinor=61
 versionPatch=0


### PR DESCRIPTION
## Summary
- merge Accounts and Settings into a single `More` screen
- update navigation and bottom bar to use the new screen
- redirect missing account prompts to `More`
- expose `AccountsContent` and `SettingsContent`
- bump version to 0.61.0

## Testing
- `./gradlew --version` *(fails: tries to download gradle)*